### PR TITLE
Feature: Extensions / Solution

### DIFF
--- a/XperienceAlgolia.sln
+++ b/XperienceAlgolia.sln
@@ -1,0 +1,48 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32421.90
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{C81B9DC5-4F3A-41A4-B5B2-79CAD18E0B16}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{F687CFA4-78FD-4F87-A81A-81965843BCA4}"
+	ProjectSection(SolutionItems) = preProject
+		.gitignore = .gitignore
+		CODE_OF_CONDUCT.md = CODE_OF_CONDUCT.md
+		CONTRIBUTING.md = CONTRIBUTING.md
+		LICENSE.md = LICENSE.md
+		README.md = README.md
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{BFF4FFD1-F72D-4420-9325-A11FD5613102}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kentico.Xperience.AlgoliaSearch", "src\Kentico.Xperience.AlgoliaSearch.csproj", "{CF8C169B-DC33-4873-A93E-DC38D8E66CFE}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kentico.Xperience.AlgoliaSearch.Tests", "tests\Kentico.Xperience.AlgoliaSearch.Tests.csproj", "{0722E27D-7206-4337-A288-2E53478C7330}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CF8C169B-DC33-4873-A93E-DC38D8E66CFE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CF8C169B-DC33-4873-A93E-DC38D8E66CFE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CF8C169B-DC33-4873-A93E-DC38D8E66CFE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CF8C169B-DC33-4873-A93E-DC38D8E66CFE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0722E27D-7206-4337-A288-2E53478C7330}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0722E27D-7206-4337-A288-2E53478C7330}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0722E27D-7206-4337-A288-2E53478C7330}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0722E27D-7206-4337-A288-2E53478C7330}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{CF8C169B-DC33-4873-A93E-DC38D8E66CFE} = {C81B9DC5-4F3A-41A4-B5B2-79CAD18E0B16}
+		{0722E27D-7206-4337-A288-2E53478C7330} = {BFF4FFD1-F72D-4420-9325-A11FD5613102}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {2BD254B2-55E1-426A-8B2E-6DFFA1E967A8}
+	EndGlobalSection
+EndGlobal

--- a/src/AlgoliaStartupExtensions.cs
+++ b/src/AlgoliaStartupExtensions.cs
@@ -17,7 +17,7 @@ namespace Kentico.Xperience.AlgoliaSearch
         /// with Dependency Injection.
         /// </summary>
         /// <param name="configuration">The application configuration.</param>
-        public static void AddAlgolia(this IServiceCollection services, IConfiguration configuration)
+        public static IServiceCollection AddAlgolia(this IServiceCollection services, IConfiguration configuration)
         {
             var algoliaOptions = configuration.GetSection(AlgoliaOptions.SECTION_NAME).Get<AlgoliaOptions>();
             var insightsClient = new InsightsClient(algoliaOptions.ApplicationId, algoliaOptions.ApiKey);
@@ -25,6 +25,8 @@ namespace Kentico.Xperience.AlgoliaSearch
 
             services.AddSingleton<IInsightsClient>(insightsClient);
             services.AddSingleton<ISearchClient>(searchClient);
+
+            return services;
         }
     }
 }


### PR DESCRIPTION
### Motivation

- Return `IServiceCollection` from the `AddAlgolia()` extension so that it doesn't break fluent chaining in configuration

    ```csharp
    services
        .AddKentico(...)
        .Services
        .AddAlgolia(...)
        .AddMyOtherLibrary(...);
    ```

- Add a root level solution file to make `dotnet` CLI commands easier to run and give developers a starting point for running / testing the library locally

    ```bash
    $ cd xperience-algolia
    $ dotnet restore
    $ dotnet build
    $ dotnet test
    ````

### Checklist

- [X] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [X] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

n/a
