### PR TITLE
Feature: Algolia ISearchIndex Customization

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,20 @@
+{
+  "files.exclude": {
+    "**/.git": true,
+    "**/.svn": true,
+    "**/.hg": true,
+    "**/CVS": true,
+    "**/.DS_Store": true
+  },
+
+  "search.exclude": {
+    "**/node_modules": true,
+    "**/bower_components": true,
+    "**/*.code-search": true,
+    "**/bin": true,
+    "**/obj": true
+  },
+
+  "omnisharp.defaultLaunchSolution": "./XperienceAlgolia.sln",
+  "omnisharp.enableImportCompletion": true
+}

--- a/src/AlgoliaQueueWorker.cs
+++ b/src/AlgoliaQueueWorker.cs
@@ -36,7 +36,7 @@ namespace Kentico.Xperience.AlgoliaSearch
         /// <summary>
         /// Adds an <see cref="AlgoliaQueueItem"/> to the worker queue to be processed.
         /// </summary>
-        /// <param name="updatedNode"></param>
+        /// <param name="queueItem"></param>
         public static void EnqueueAlgoliaQueueItem(AlgoliaQueueItem queueItem)
         {
             if (queueItem == null || queueItem.Node == null || String.IsNullOrEmpty(queueItem.IndexName))

--- a/src/AlgoliaStartupExtensions.cs
+++ b/src/AlgoliaStartupExtensions.cs
@@ -18,6 +18,7 @@ namespace Kentico.Xperience.AlgoliaSearch
         /// Registers instances of <see cref="IInsightsClient"/> and <see cref="ISearchClient"/>
         /// with Dependency Injection.
         /// </summary>
+        /// <param name="services"></param>
         /// <param name="configuration">The application configuration.</param>
         public static IServiceCollection AddAlgolia(this IServiceCollection services, IConfiguration configuration)
         {

--- a/src/Kentico.Xperience.AlgoliaSearch.csproj
+++ b/src/Kentico.Xperience.AlgoliaSearch.csproj
@@ -21,6 +21,7 @@
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<NoWarn>1591</NoWarn>
+		<LangVersion>7.3</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition=" $(Configuration) == 'Release' ">

--- a/src/Models/Facets/AlgoliaFacetFilterViewModel.cs
+++ b/src/Models/Facets/AlgoliaFacetFilterViewModel.cs
@@ -1,6 +1,4 @@
-﻿using Algolia.Search.Models.Search;
-
-using Kentico.Xperience.AlgoliaSearch.Attributes;
+﻿using Kentico.Xperience.AlgoliaSearch.Attributes;
 
 using Microsoft.Extensions.Localization;
 

--- a/src/Models/Facets/IAlgoliaFacetFilter.cs
+++ b/src/Models/Facets/IAlgoliaFacetFilter.cs
@@ -15,7 +15,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Models.Facets
         /// <summary>
         /// A collection of an Algolia index's faceted attributes and the available facets.
         /// </summary>
-        public abstract AlgoliaFacetedAttribute[] FacetedAttributes
+        AlgoliaFacetedAttribute[] FacetedAttributes
         {
             get;
             set;
@@ -28,7 +28,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Models.Facets
         /// </summary>
         /// <param name="searchModelType">The Algolia search model that is being used in
         /// the current query. If null, all facet filters will use the "OR" condition.</param>
-        public string GetFilter(Type searchModelType = null);
+        string GetFilter(Type searchModelType = null);
 
 
         /// <summary>

--- a/src/Services/IAlgoliaConnection.cs
+++ b/src/Services/IAlgoliaConnection.cs
@@ -23,7 +23,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
         /// or null.</exception>
         /// <exception cref="InvalidOperationException">Thrown if the search model is configured
         /// incorrectly or index settings cannot be loaded.</exception>
-        public void Initialize(string indexName);
+        void Initialize(string indexName);
 
 
         /// <summary>
@@ -33,7 +33,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
         /// </summary>
         /// <param name="objectIds">The Algolia internal IDs of the records to delete.</param>
         /// <returns>The number of records deleted.</returns>
-        public int DeleteRecords(IEnumerable<string> objectIds);
+        int DeleteRecords(IEnumerable<string> objectIds);
 
 
         /// <summary>
@@ -44,7 +44,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
         /// <remarks>Logs an error if there are issues loading the node data.</remarks>
         /// <param name="dataObjects">The objects to upsert into Algolia.</param>
         /// <returns>The number of objects processed.</returns>
-        public int UpsertRecords(IEnumerable<JObject> dataObjects);
+        int UpsertRecords(IEnumerable<JObject> dataObjects);
 
 
         /// <summary>
@@ -53,6 +53,6 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
         /// </summary>
         /// <exception cref="InvalidOperationException">Thrown if a search model class is not
         /// found for the index.</exception>
-        public void Rebuild();
+        void Rebuild();
     }
 }

--- a/src/Services/IAlgoliaIndexService.cs
+++ b/src/Services/IAlgoliaIndexService.cs
@@ -1,0 +1,17 @@
+using Algolia.Search.Clients;
+
+namespace Kentico.Xperience.AlgoliaSearch.Services
+{
+    /// <summary>
+    /// Initializes <see cref="ISearchIndex" /> instances
+    /// </summary>
+    public interface IAlgoliaIndexService
+    {
+        /// <summary>
+        /// Initializes a new <see cref="ISearchIndex" /> for the given <paramref name="indexName" />.
+        /// </summary>
+        /// <param name="indexName"></param>
+        /// <returns></returns>
+        ISearchIndex InitializeIndex(string indexName);
+    }
+}

--- a/src/Services/IAlgoliaIndexingService.cs
+++ b/src/Services/IAlgoliaIndexingService.cs
@@ -23,7 +23,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
         /// <param name="node">The <see cref="TreeNode"/> that triggered the event.</param>
         /// <param name="wasDeleted">True if the <paramref name="node"/> was deleted.</param>
         /// <param name="isNew">True if the <paramref name="node"/> was created.</param>
-        public void EnqueueAlgoliaItems(TreeNode node, bool wasDeleted, bool isNew);
+        void EnqueueAlgoliaItems(TreeNode node, bool wasDeleted, bool isNew);
 
 
         /// <summary>
@@ -36,7 +36,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
         /// <returns>A <see cref="JObject"/> with its properties and values set.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="node"/> or
         /// <paramref name="searchModelType"/> are null.</exception>
-        public JObject GetTreeNodeData(TreeNode node, Type searchModelType);
+        JObject GetTreeNodeData(TreeNode node, Type searchModelType);
 
 
         /// <summary>
@@ -47,6 +47,6 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
         /// <remarks>Logs errors if there are issues initializing the <see cref="IAlgoliaConnection"/>.</remarks>
         /// <param name="items">The items to process.</param>
         /// <returns>The number of items processed.</returns>
-        public int ProcessAlgoliaTasks(IEnumerable<AlgoliaQueueItem> items);
+        int ProcessAlgoliaTasks(IEnumerable<AlgoliaQueueItem> items);
     }
 }

--- a/src/Services/IAlgoliaInsightsService.cs
+++ b/src/Services/IAlgoliaInsightsService.cs
@@ -23,7 +23,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
         /// </summary>
         /// <returns>The response from Algolia, or null if the request was skipped or an error occurred communicating
         /// with Algolia.</returns>
-        public Task<InsightsResponse> LogSearchResultClicked(string eventName, string indexName);
+        Task<InsightsResponse> LogSearchResultClicked(string eventName, string indexName);
 
 
         /// <summary>
@@ -32,7 +32,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
         /// </summary>
         /// <returns>The response from Algolia, or null if the request was skipped or an error occurred communicating
         /// with Algolia.</returns>
-        public Task<InsightsResponse> LogSearchResultConversion(string conversionName, string indexName);
+        Task<InsightsResponse> LogSearchResultConversion(string conversionName, string indexName);
 
 
         /// <summary>
@@ -44,7 +44,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
         /// <param name="indexName">The code name of the Algolia index.</param>
         /// <returns>The response from Algolia, or null if the request was skipped or an error occurred communicating
         /// with Algolia.</returns>
-        public Task<InsightsResponse> LogPageConversion(int documentId, string conversionName, string indexName);
+        Task<InsightsResponse> LogPageConversion(int documentId, string conversionName, string indexName);
 
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
         /// <param name="indexName">The code name of the Algolia index.</param>
         /// <returns>The response from Algolia, or null if the request was skipped or an error occurred communicating
         /// with Algolia.</returns>
-        public Task<InsightsResponse> LogPageViewed(int documentId, string eventName, string indexName);
+        Task<InsightsResponse> LogPageViewed(int documentId, string eventName, string indexName);
 
 
         /// <summary>
@@ -68,7 +68,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
         /// <param name="indexName">The code name of the Algolia index.</param>
         /// <returns>The response from Algolia, or null if the request was skipped or an error occurred communicating
         /// with Algolia.</returns>
-        public Task<InsightsResponse> LogFacetsViewed(IEnumerable<AlgoliaFacetedAttribute> facets, string eventName, string indexName);
+        Task<InsightsResponse> LogFacetsViewed(IEnumerable<AlgoliaFacetedAttribute> facets, string eventName, string indexName);
 
 
         /// <summary>
@@ -79,7 +79,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
         /// <param name="indexName">The code name of the Algolia index.</param>
         /// <returns>The response from Algolia, or null if the request was skipped or an error occurred communicating
         /// with Algolia.</returns>
-        public Task<InsightsResponse> LogFacetClicked(string facet, string eventName, string indexName);
+        Task<InsightsResponse> LogFacetClicked(string facet, string eventName, string indexName);
 
 
         /// <summary>
@@ -90,7 +90,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
         /// <param name="indexName">The code name of the Algolia index.</param>
         /// <returns>The response from Algolia, or null if the request was skipped or an error occurred communicating
         /// with Algolia.</returns>
-        public Task<InsightsResponse> LogFacetConverted(string facet, string conversionName, string indexName);
+        Task<InsightsResponse> LogFacetConverted(string facet, string conversionName, string indexName);
 
 
         /// <summary>
@@ -99,6 +99,6 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
         /// </summary>
         /// <typeparam name="TModel">The type of the Algolia search model.</typeparam>
         /// <param name="searchResponse">The full response of an Algolia search.</param>
-        public void SetInsightsUrls<TModel>(SearchResponse<TModel> searchResponse) where TModel : AlgoliaSearchModel;
+        void SetInsightsUrls<TModel>(SearchResponse<TModel> searchResponse) where TModel : AlgoliaSearchModel;
     }
 }

--- a/src/Services/IAlgoliaRegistrationService.cs
+++ b/src/Services/IAlgoliaRegistrationService.cs
@@ -1,4 +1,5 @@
-﻿using Algolia.Search.Models.Settings;
+﻿using Algolia.Search.Clients;
+using Algolia.Search.Models.Settings;
 
 using CMS.DocumentEngine;
 
@@ -20,7 +21,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
         /// A collection of registered Algolia indexes as identified by the
         /// <see cref="RegisterAlgoliaIndexAttribute"/> in the search model class.
         /// </summary>
-        public List<RegisterAlgoliaIndexAttribute> RegisteredIndexes
+        List<RegisterAlgoliaIndexAttribute> RegisteredIndexes
         {
             get;
         }
@@ -31,7 +32,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
         /// </summary>
         /// <remarks>Logs an error if the were issues scanning the assembly.</remarks>
         /// <param name="assembly">The assembly to scan for attributes.</param>
-        public IEnumerable<RegisterAlgoliaIndexAttribute> GetAlgoliaIndexAttributes(Assembly assembly);
+        IEnumerable<RegisterAlgoliaIndexAttribute> GetAlgoliaIndexAttributes(Assembly assembly);
 
 
         /// <summary>
@@ -40,7 +41,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
         /// <param name="indexName">The Algolia index code name.</param>
         /// <returns>The index settings, or null if not found.</returns>
         /// <exception cref="ArgumentNullException"></exception>
-        public IndexSettings GetIndexSettings(string indexName);
+        IndexSettings GetIndexSettings(string indexName);
 
 
         /// <summary>
@@ -51,7 +52,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
         /// </summary>
         /// <param name="indexName">The code name of the Algolia index.</param>
         /// <returns>The names of the database columns that are indexed, or an empty array.</returns>
-        public string[] GetIndexedColumnNames(string indexName);
+        string[] GetIndexedColumnNames(string indexName);
 
 
         /// <summary>
@@ -59,7 +60,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
         /// </summary>
         /// <param name="node">The <see cref="TreeNode"/> to check for indexing.</param>
         /// <exception cref="ArgumentNullException"></exception>
-        public bool IsNodeAlgoliaIndexed(TreeNode node);
+        bool IsNodeAlgoliaIndexed(TreeNode node);
 
 
         /// <summary>
@@ -70,7 +71,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
         /// <param name="node">The node to check for indexing.</param>
         /// <param name="indexName">The Algolia index code name.</param>
         /// <exception cref="ArgumentNullException"></exception>
-        public bool IsNodeIndexedByIndex(TreeNode node, string indexName);
+        bool IsNodeIndexedByIndex(TreeNode node, string indexName);
 
 
         /// <summary>
@@ -80,7 +81,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
         /// based on the attributes defined in the search model.
         /// </summary>
         /// <remarks>Logs an error if the index settings cannot be loaded.</remarks>
-        public void RegisterAlgoliaIndexes();
+        void RegisterAlgoliaIndexes();
 
 
         /// <summary>
@@ -89,6 +90,6 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
         /// <remarks>Logs errors if the parameters are invalid, or the index is already registered.</remarks>
         /// <param name="registerAlgoliaIndexAttribute">The <see cref="RegisterAlgoliaIndexAttribute"/> defined
         /// in the search model code file.</param>
-        public void RegisterIndex(RegisterAlgoliaIndexAttribute registerAlgoliaIndexAttribute);
+        void RegisterIndex(RegisterAlgoliaIndexAttribute registerAlgoliaIndexAttribute);
     }
 }

--- a/src/Services/IAlgoliaSearchService.cs
+++ b/src/Services/IAlgoliaSearchService.cs
@@ -19,7 +19,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
         /// Gets the indices of the Algolia application with basic statistics.
         /// </summary>
         /// <remarks>See <see href="https://www.algolia.com/doc/api-reference/api-methods/list-indices/#response"/></remarks>
-        public List<IndicesResponse> GetStatistics();
+        List<IndicesResponse> GetStatistics();
 
 
         /// <summary>
@@ -33,7 +33,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
         /// to the returned list with a count of zero.</param>
         /// <returns>A new list of <see cref="AlgoliaFacetedAttribute"/>s that are available to filter search
         /// results.</returns>
-        public AlgoliaFacetedAttribute[] GetFacetedAttributes(Dictionary<string, Dictionary<string, long>> facetsFromResponse, IAlgoliaFacetFilter filter = null, bool displayEmptyFacets = true);
+        AlgoliaFacetedAttribute[] GetFacetedAttributes(Dictionary<string, Dictionary<string, long>> facetsFromResponse, IAlgoliaFacetFilter filter = null, bool displayEmptyFacets = true);
 
 
         /// <summary>
@@ -45,13 +45,13 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
         /// <exception cref="InvalidOperationException">Thrown if the <see cref="FacetableAttribute"/>
         /// has both <see cref="FacetableAttribute.FilterOnly"/> and <see cref="FacetableAttribute.Searchable"/>
         /// set to true.</exception>
-        public string GetFilterablePropertyName(PropertyInfo property);
+        string GetFilterablePropertyName(PropertyInfo property);
 
 
         /// <summary>
         /// Returns true if Algolia indexing is enabled, or if the settings key doesn't exist.
         /// </summary>
-        public bool IsIndexingEnabled();
+        bool IsIndexingEnabled();
 
 
         /// <summary>
@@ -62,6 +62,6 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
         /// <param name="searchableProperties">The properties of the search model to be ordered.</param>
         /// <returns>A list of strings appropriate for setting Algolia searchable attributes (see
         /// <see href="https://www.algolia.com/doc/api-reference/api-parameters/searchableAttributes/"/>).</returns>
-        public List<string> OrderSearchableProperties(IEnumerable<PropertyInfo> searchableProperties);
+        List<string> OrderSearchableProperties(IEnumerable<PropertyInfo> searchableProperties);
     }
 }

--- a/src/Services/Implementations/DefaultAlgoliaIndexService.cs
+++ b/src/Services/Implementations/DefaultAlgoliaIndexService.cs
@@ -1,0 +1,25 @@
+using Algolia.Search.Clients;
+using CMS;
+using CMS.Core;
+using Kentico.Xperience.AlgoliaSearch.Services;
+
+[assembly: RegisterImplementation(typeof(IAlgoliaIndexService), typeof(DefaultAlgoliaIndexService), Lifestyle = Lifestyle.Singleton, Priority = RegistrationPriority.SystemDefault)]
+
+namespace Kentico.Xperience.AlgoliaSearch.Services
+{
+    /// <inheritdoc />
+    public class DefaultAlgoliaIndexService : IAlgoliaIndexService
+    {
+        private readonly ISearchClient searchClient;
+
+        public DefaultAlgoliaIndexService(ISearchClient searchClient)
+        {
+            this.searchClient = searchClient;
+        }
+
+        public ISearchIndex InitializeIndex(string indexName)
+        {
+            return searchClient.InitIndex(indexName);
+        }
+    }
+}

--- a/src/Services/Implementations/DefaultAlgoliaIndexingService.cs
+++ b/src/Services/Implementations/DefaultAlgoliaIndexingService.cs
@@ -21,7 +21,7 @@ using System.Reflection;
 namespace Kentico.Xperience.AlgoliaSearch.Services
 {
     /// <summary>
-    /// Default implementation of <see cref="AlgoliaIndexingService"/>.
+    /// Default implementation of <see cref="IAlgoliaIndexingService"/>.
     /// </summary>
     internal class DefaultAlgoliaIndexingService : IAlgoliaIndexingService
     {

--- a/src/Services/Implementations/DefaultAlgoliaRegistrationService.cs
+++ b/src/Services/Implementations/DefaultAlgoliaRegistrationService.cs
@@ -25,8 +25,9 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
         private readonly IAlgoliaSearchService algoliaSearchService;
         private readonly IEventLogService eventLogService;
         private readonly ISearchClient searchClient;
-        private List<RegisterAlgoliaIndexAttribute> mRegisteredIndexes = new List<RegisterAlgoliaIndexAttribute>();
-        private string[] ignoredPropertiesForTrackingChanges = new string[] {
+        private readonly IAlgoliaIndexService algoliaIndexService;
+        private readonly List<RegisterAlgoliaIndexAttribute> mRegisteredIndexes = new List<RegisterAlgoliaIndexAttribute>();
+        private readonly string[] ignoredPropertiesForTrackingChanges = new string[] {
             nameof(AlgoliaSearchModel.ObjectID),
             nameof(AlgoliaSearchModel.Url),
             nameof(AlgoliaSearchModel.ClassName)
@@ -47,11 +48,13 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
         /// </summary>
         public DefaultAlgoliaRegistrationService(IAlgoliaSearchService algoliaSearchService,
             IEventLogService eventLogService,
-            ISearchClient searchClient)
+            ISearchClient searchClient,
+            IAlgoliaIndexService algoliaIndexService)
         {
             this.algoliaSearchService = algoliaSearchService;
             this.eventLogService = eventLogService;
             this.searchClient = searchClient;
+            this.algoliaIndexService = algoliaIndexService;
         }
 
 
@@ -220,7 +223,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
                 {
                     RegisterIndex(attribute);
 
-                    var searchIndex = searchClient.InitIndex(attribute.IndexName);
+                    var searchIndex = algoliaIndexService.InitializeIndex(attribute.IndexName);
                     var indexSettings = GetIndexSettings(attribute.IndexName);
                     if (indexSettings == null)
                     {

--- a/tests/Fakes/FakeNodes.cs
+++ b/tests/Fakes/FakeNodes.cs
@@ -9,7 +9,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Test
 {
     internal class FakeNodes
     {
-        private static Dictionary<string, TreeNode> nodes = new Dictionary<string, TreeNode>();
+        private static readonly Dictionary<string, TreeNode> nodes = new Dictionary<string, TreeNode>();
 
 
         public static string DOCTYPE_ARTICLE = "Test.Article";

--- a/tests/Tests/IAlgoliaRegistrationServiceTests.cs
+++ b/tests/Tests/IAlgoliaRegistrationServiceTests.cs
@@ -31,7 +31,8 @@ namespace Kentico.Xperience.AlgoliaSearch.Test
             {
                 var mockSearchClient = Substitute.For<ISearchClient>();
                 var algoliaSearchService = new DefaultAlgoliaSearchService(mockSearchClient);
-                algoliaRegistrationService = new DefaultAlgoliaRegistrationService(algoliaSearchService, new MockEventLogService(), mockSearchClient);
+                var mockIndexService = Substitute.For<IAlgoliaIndexService>();
+                algoliaRegistrationService = new DefaultAlgoliaRegistrationService(algoliaSearchService, new MockEventLogService(), mockSearchClient, mockIndexService);
 
                 var attributes = algoliaRegistrationService.GetAlgoliaIndexAttributes(Assembly.GetExecutingAssembly());
                 foreach (var attribute in attributes)
@@ -114,7 +115,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Test
             [SetUp]
             public void IsNodeAlgoliaIndexed_SetUp()
             {
-                algoliaRegistrationService = new DefaultAlgoliaRegistrationService(Substitute.For<IAlgoliaSearchService>(), new MockEventLogService(), Substitute.For<ISearchClient>());
+                algoliaRegistrationService = new DefaultAlgoliaRegistrationService(Substitute.For<IAlgoliaSearchService>(), new MockEventLogService(), Substitute.For<ISearchClient>(), Substitute.For<IAlgoliaIndexService>());
 
                 var attributes = algoliaRegistrationService.GetAlgoliaIndexAttributes(Assembly.GetExecutingAssembly());
                 foreach (var attribute in attributes)
@@ -153,7 +154,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Test
             [SetUp]
             public void IsNodeIndexedByIndexTests_SetUp()
             {
-                algoliaRegistrationService = new DefaultAlgoliaRegistrationService(Substitute.For<IAlgoliaSearchService>(), new MockEventLogService(), Substitute.For<ISearchClient>());
+                algoliaRegistrationService = new DefaultAlgoliaRegistrationService(Substitute.For<IAlgoliaSearchService>(), new MockEventLogService(), Substitute.For<ISearchClient>(), Substitute.For<IAlgoliaIndexService>());
 
                 var attributes = algoliaRegistrationService.GetAlgoliaIndexAttributes(Assembly.GetExecutingAssembly());
                 foreach (var attribute in attributes)
@@ -228,7 +229,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Test
             [SetUp]
             public void GetIndexedColumnNamesTests_SetUp()
             {
-                algoliaRegistrationService = new DefaultAlgoliaRegistrationService(Substitute.For<IAlgoliaSearchService>(), new MockEventLogService(), Substitute.For<ISearchClient>());
+                algoliaRegistrationService = new DefaultAlgoliaRegistrationService(Substitute.For<IAlgoliaSearchService>(), new MockEventLogService(), Substitute.For<ISearchClient>(), Substitute.For<IAlgoliaIndexService>());
 
                 var attributes = algoliaRegistrationService.GetAlgoliaIndexAttributes(Assembly.GetExecutingAssembly());
                 foreach (var attribute in attributes)
@@ -262,7 +263,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Test
             [SetUp]
             public void RegisterIndexTests_SetUp()
             {
-                algoliaRegistrationService = new DefaultAlgoliaRegistrationService(Substitute.For<IAlgoliaSearchService>(), new MockEventLogService(), Substitute.For<ISearchClient>());
+                algoliaRegistrationService = new DefaultAlgoliaRegistrationService(Substitute.For<IAlgoliaSearchService>(), new MockEventLogService(), Substitute.For<ISearchClient>(), Substitute.For<IAlgoliaIndexService>());
             }
 
 

--- a/tests/Tests/IAlgoliaSearchServiceTests.cs
+++ b/tests/Tests/IAlgoliaSearchServiceTests.cs
@@ -31,7 +31,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Test
             }
 
 
-            private Dictionary<string, Dictionary<string, long>> facetsFromResponse = new Dictionary<string, Dictionary<string, long>>()
+            private readonly Dictionary<string, Dictionary<string, long>> facetsFromResponse = new Dictionary<string, Dictionary<string, long>>()
             {
                 {
                     "attr1",
@@ -44,7 +44,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Test
             };
 
 
-            private AlgoliaFacetedAttribute[] facetsFromFilter = new AlgoliaFacetedAttribute[] {
+            private readonly AlgoliaFacetedAttribute[] facetsFromFilter = new AlgoliaFacetedAttribute[] {
                 new AlgoliaFacetedAttribute() {
                     Attribute = "attr1",
                     Facets = new AlgoliaFacet[] {


### PR DESCRIPTION
### Motivation

Fixes #15 by adding a new `IAlgoliaIndexService` and a default implementation of `DefaultAlgoliaIndexService` which reproduces the existing behavior.

Developers can use [decoration](https://docs.xperience.io/custom-development/decorating-system-services#Decoratingsystemservices-Decorateservicesviadependencyinjection) to get access to the `IAlgoliaIndexService`, or use the `ISearchClient` directly to generate a new index.

The latter approach also allows developers to target a different index per-environment, which isn't currently possible because index names have to be `const string` values on the index model.

This PR also addresses the following issues:

- Adds VS Code editing support with workspace settings (defines the solution file for Omnisharp)
- Sets an explicit language version in `Kentico.Xperience.AlgoliaSearch.csproj` to C# 7.3, because this is what is compatible with `netstandard2.0` which is what the library targets
- Removes `public` modifier from all interface methods because this is not supported with C# 7.3
  - Also removes `abstract` interface method modifier which is only useful when other methods provide default implementations
- Fixes XML doc comments
- Fixes C# standard analyzer warnings for internal code (no public API change)

### Checklist

- [X] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [X] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

No tests were added since the new abstraction has the exact same behavior as the existing code.

`dotnet test`
