### PR TITLE
Feature: Register IOptions<AlgoliaOptions> for DI

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,10 +444,10 @@ Algolia provides [autocomplete](https://www.algolia.com/doc/ui-libraries/autocom
 3. Load the Algolia keys from `appsettings.json`:
 
 ```cshtml
-@inject IConfiguration configuration
+@inject IOptions<AlgoliaOptions> options
 
 @{
-    var algoliaOptions = configuration.GetSection(AlgoliaOptions.SECTION_NAME).Get<AlgoliaOptions>();
+    var algoliaOptions = options.Value;
 }
 ```
 
@@ -1065,10 +1065,10 @@ endpoints.MapControllerRoute(
 2. Create the _Index.cshtml_ view for your controller with the basic layout and stylesheet references. Load your Algolia settings for use later:
 
 ```cshtml
-@inject IConfiguration configuration
+@inject IOptions<AlgoliaOptions> options
 
 @{
-    var algoliaOptions = configuration.GetSection(AlgoliaOptions.SECTION_NAME).Get<AlgoliaOptions>();
+    var algoliaOptions = options.Value;
 }
 
 @section styles {


### PR DESCRIPTION
### Motivation

The current recommended approach for getting access to the Algolia configuration in the ASP.NET Core application from app settings is the following:

```html
@inject IConfiguration configuration

@{
    var algoliaOptions = configuration.GetSection(AlgoliaOptions.SECTION_NAME).Get<AlgoliaOptions>();
}
```

This block of code needs to be repeated wherever these settings are needed. It's also not recommended to inject `IConfiguration` across an application because it makes it difficult to determine what parts of configuration are being used by an application.

However, .NET already provides patterns for validating configuration and injecting it across an application with [IOptions<T> and PostConfigure](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/options?view=aspnetcore-6.0#options-post-configuration).

This PR makes the `AlgoliaOptions` available through `IOptions<AlgoliaOptions>` and also ensures the options get populated with default values before they are used.

There are no breaking changes since developers can still use `IConfiguration.GetSection(AlgoliaOptions.SECTION_NAME).Get<AlgoliaOptions>();` if they want.

### Checklist

- [X] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [X] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

1. Setup app using this library
2. Do not provide any settings values
3. Inject `IOptions<AlgoliaOptions>` into user-code (Controller/View Component/View) and verify default settings are available
4. Supply settings values
5. Inject `IOptions<AlgoliaOptions>` into user-code (Controller/View Component/View) and verify custom settings are available