### PR TITLE
Feature: Register IOptions<AlgoliaOptions> for DI

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,9 +465,11 @@ Algolia provides [autocomplete](https://www.algolia.com/doc/ui-libraries/autocom
 3. Load the Algolia keys from `appsettings.json`:
 
 ```cshtml
-@inject IConfiguration configuration
+@using Microsoft.Extensions.Options
+@inject IOptions<AlgoliaOptions> options
+
 @{
-    var algoliaOptions = configuration.GetSection(AlgoliaOptions.SECTION_NAME).Get<AlgoliaOptions>();
+    var algoliaOptions = options.Value;
 }
 ```
 
@@ -1087,9 +1089,11 @@ endpoints.MapControllerRoute(
 2. Create the _Index.cshtml_ view for your controller with the basic layout and stylesheet references. Load your Algolia settings for use later:
 
 ```cshtml
-@inject IConfiguration configuration
+@using Microsoft.Extensions.Options
+@inject IOptions<AlgoliaOptions> options
+
 @{
-    var algoliaOptions = configuration.GetSection(AlgoliaOptions.SECTION_NAME).Get<AlgoliaOptions>();
+    var algoliaOptions = options.Value;
 }
 
 @section styles {

--- a/src/AlgoliaStartupExtensions.cs
+++ b/src/AlgoliaStartupExtensions.cs
@@ -1,12 +1,13 @@
-﻿using Algolia.Search.Clients;
+﻿using System;
+
+using Algolia.Search.Clients;
 
 using Kentico.Xperience.AlgoliaSearch.Models;
 using Kentico.Xperience.AlgoliaSearch.Services;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-
-using System;
+using Microsoft.Extensions.Options;
 
 namespace Kentico.Xperience.AlgoliaSearch
 {
@@ -24,23 +25,32 @@ namespace Kentico.Xperience.AlgoliaSearch
         /// <param name="register">The implementation of <see cref="IAlgoliaIndexRegister"/> to register.</param>
         public static IServiceCollection AddAlgolia(this IServiceCollection services, IConfiguration configuration, IAlgoliaIndexRegister register)
         {
-            var algoliaOptions = configuration.GetSection(AlgoliaOptions.SECTION_NAME).Get<AlgoliaOptions>();
-            if (String.IsNullOrEmpty(algoliaOptions.ApplicationId) || String.IsNullOrEmpty(algoliaOptions.ApiKey))
+            services.Configure<AlgoliaOptions>(configuration.GetSection(AlgoliaOptions.SECTION_NAME));
+            services.PostConfigure<AlgoliaOptions>(options =>
             {
-                // Algolia configuration is not valid, but IEventLogService can't be resolved during startup.
-                // Set dummy values so that DI is not broken, but errors can be captured when attempting to use the client
-                algoliaOptions.ApplicationId = "NO_APP";
-                algoliaOptions.ApiKey = "NO_KEY";
-            }
+                if (String.IsNullOrEmpty(options.ApplicationId) || String.IsNullOrEmpty(options.ApiKey))
+                {
+                    // Algolia configuration is not valid, but IEventLogService can't be resolved during startup.
+                    // Set dummy values so that DI is not broken, but errors can be captured when attempting to use the client
+                    options.ApplicationId = "NO_APP";
+                    options.ApiKey = "NO_KEY";
+                }
+            });
 
-            var insightsClient = new InsightsClient(algoliaOptions.ApplicationId, algoliaOptions.ApiKey);
-            var searchClient = new SearchClient(algoliaOptions.ApplicationId, algoliaOptions.ApiKey);
+            return services
+                .AddSingleton<IInsightsClient>(s =>
+                {
+                    var options = s.GetRequiredService<IOptions<AlgoliaOptions>>();
 
-            services.AddSingleton<IInsightsClient>(insightsClient);
-            services.AddSingleton<ISearchClient>(searchClient);
-            services.AddSingleton(register);
+                    return new InsightsClient(options.Value.ApplicationId, options.Value.ApiKey);
+                })
+                .AddSingleton<ISearchClient>(s =>
+                {
+                    var options = s.GetRequiredService<IOptions<AlgoliaOptions>>();
 
-            return services;
+                    return new SearchClient(options.Value.ApplicationId, options.Value.ApiKey);
+                })
+                .AddSingleton(register);
         }
     }
 }

--- a/src/Kentico.Xperience.AlgoliaSearch.csproj
+++ b/src/Kentico.Xperience.AlgoliaSearch.csproj
@@ -9,7 +9,7 @@
 	<PropertyGroup>
 		<Title>Xperience Algolia Search</Title>
 		<PackageId>Kentico.Xperience.AlgoliaSearch</PackageId>
-		<Version>3.0.0</Version>
+		<Version>3.1.0</Version>
 		<Authors>Kentico Software</Authors>
 		<Company>Kentico Software</Company>
 		<PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
### Motivation

The current recommended approach for getting access to the Algolia configuration in the ASP.NET Core application from app settings is the following:

```html
@inject IConfiguration configuration

@{
    var algoliaOptions = configuration.GetSection(AlgoliaOptions.SECTION_NAME).Get<AlgoliaOptions>();
}
```

This block of code needs to be repeated wherever these settings are needed. It's also not recommended to inject `IConfiguration` across an application because it makes it difficult to determine what parts of configuration are being used by an application.

However, .NET already provides patterns for validating configuration and injecting it across an application with [IOptions<T> and PostConfigure](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/options?view=aspnetcore-6.0#options-post-configuration).

This PR makes the `AlgoliaOptions` available through `IOptions<AlgoliaOptions>` and also ensures the options get populated with default values before they are used.

There are no breaking changes since developers can still use `IConfiguration.GetSection(AlgoliaOptions.SECTION_NAME).Get<AlgoliaOptions>();` if they want.

### Checklist

- [X] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [X] Tests are passing
- [X] Docs have been updated (if applicable)
- [X] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

1. Setup app using this library
2. Do not provide any settings values
3. Inject `IOptions<AlgoliaOptions>` into user-code (Controller/View Component/View) and verify default settings are available
4. Supply settings values
5. Inject `IOptions<AlgoliaOptions>` into user-code (Controller/View Component/View) and verify custom settings are available