### PR TITLE
Feat/distinct index

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,1245 @@
+﻿root = true
+
+[*.cs]
+
+# ===== Active SonarLint rules =====
+
+# [Category: Bug]
+# S2757: "=+" should not be used instead of "+="
+dotnet_diagnostic.S2757.severity = warning
+
+# S3168: "async" methods should not return "void"
+dotnet_diagnostic.S3168.severity = warning
+
+# S3397: "base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"
+dotnet_diagnostic.S3397.severity = warning
+
+# S1206: "Equals(Object)" and "GetHashCode()" should be overridden in pairs
+dotnet_diagnostic.S1206.severity = warning
+
+# S2328: "GetHashCode" should not reference mutable fields
+dotnet_diagnostic.S2328.severity = warning
+
+# S2997: "IDisposables" created in a "using" statement should not be returned
+dotnet_diagnostic.S2997.severity = warning
+
+# S2930: "IDisposables" should be disposed
+dotnet_diagnostic.S2930.severity = warning
+
+# S2688: "NaN" should not be used in comparisons
+dotnet_diagnostic.S2688.severity = warning
+
+# S2995: "Object.ReferenceEquals" should not be used for value types
+dotnet_diagnostic.S2995.severity = warning
+
+# S3869: "SafeHandle.DangerousGetHandle" should not be called
+dotnet_diagnostic.S3869.severity = warning
+
+# S3456: "string.ToCharArray()" should not be called redundantly
+dotnet_diagnostic.S3456.severity = warning
+
+# S2996: "ThreadStatic" fields should not be initialized
+dotnet_diagnostic.S2996.severity = warning 
+
+# S3005: "ThreadStatic" should not be used on non-static fields
+dotnet_diagnostic.S3005.severity = warning
+
+# S2225: "ToString()" method should not return null
+dotnet_diagnostic.S2225.severity = warning
+
+# S2251: A "for" loop update clause should move the counter in the right direction
+dotnet_diagnostic.S2251.severity = warning
+
+# S3923: All branches in a conditional structure should not have exactly the same implementation
+dotnet_diagnostic.S3923.severity = warning
+
+# S3244: Anonymous delegates should not be used to unsubscribe from Events
+dotnet_diagnostic.S3244.severity = warning
+
+# S3343: Caller information parameters should come at the end of the parameter list
+dotnet_diagnostic.S3343.severity = warning
+
+# S4583: Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
+dotnet_diagnostic.S4583.severity = warning
+
+# S3249: Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
+dotnet_diagnostic.S3249.severity = warning
+
+# S3453: Classes should not have only "private" constructors
+dotnet_diagnostic.S3453.severity = warning
+
+# S4143: Collection elements should not be replaced unconditionally
+dotnet_diagnostic.S4143.severity = warning
+
+# S3981: Collection sizes and array length comparisons should make sense
+dotnet_diagnostic.S3981.severity = warning
+
+# S2114: Collections should not be passed as arguments to their own methods
+dotnet_diagnostic.S2114.severity = warning
+
+# S2275: Composite format strings should not lead to unexpected behavior at runtime
+dotnet_diagnostic.S2275.severity = warning
+
+# S2583: Conditionally executed code should be reachable
+dotnet_diagnostic.S2583.severity = warning
+
+# S3172: Delegates should not be subtracted
+dotnet_diagnostic.S3172.severity = warning
+
+# S3926: Deserialization methods should be provided for "OptionalField" members
+dotnet_diagnostic.S3926.severity = warning
+
+# S1048: Destructors should not throw exceptions
+dotnet_diagnostic.S1048.severity = warning
+
+# S2761: Doubled prefix operators "!!" and "~~" should not be used
+dotnet_diagnostic.S2761.severity = warning
+
+# S4158: Empty collections should not be accessed or iterated
+dotnet_diagnostic.S4158.severity = warning
+
+# S3655: Empty nullable value should not be accessed
+dotnet_diagnostic.S3655.severity = warning
+
+# S3984: Exceptions should not be created without being thrown
+dotnet_diagnostic.S3984.severity = warning
+
+# S3346: Expressions used in "Debug.Assert" should not produce side effects
+dotnet_diagnostic.S3346.severity = warning
+
+# S2345: Flags enumerations should explicitly initialize all their members
+dotnet_diagnostic.S2345.severity = warning
+
+# S2252: For-loop conditions should be true at least once
+dotnet_diagnostic.S2252.severity = warning
+
+# S4275: Getters and setters should access the expected fields
+dotnet_diagnostic.S4275.severity = warning
+
+# S1764: Identical expressions should not be used on both sides of a binary operator
+dotnet_diagnostic.S1764.severity = warning
+
+# S2183: Integral numbers should not be shifted by zero or more than their number of bits-1
+dotnet_diagnostic.S2183.severity = warning
+
+# S1751: Loops with at most one iteration should be refactored
+dotnet_diagnostic.S1751.severity = warning
+
+# S3603: Methods with "Pure" attribute should return a value
+dotnet_diagnostic.S3603.severity = warning
+
+# S3887: Mutable, non-private fields should not be "readonly"
+dotnet_diagnostic.S3887.severity = warning
+
+# S3889: Neither "Thread.Resume" nor "Thread.Suspend" should be used
+dotnet_diagnostic.S3889.severity = warning
+
+# S4586: Non-async "Task/Task<T>" methods should not return null
+dotnet_diagnostic.S4586.severity = warning
+
+# S2259: Null pointers should not be dereferenced
+dotnet_diagnostic.S2259.severity = warning
+
+# S3610: Nullable type comparison should not be redundant
+dotnet_diagnostic.S3610.severity = warning
+
+# S1848: Objects should not be created to be dropped immediately without being used
+dotnet_diagnostic.S1848.severity = warning
+
+# S3598: One-way "OperationContract" methods should have "void" return type
+dotnet_diagnostic.S3598.severity = warning
+
+# S3466: Optional parameters should be passed to "base" calls
+dotnet_diagnostic.S3466.severity = warning
+
+# S2934: Property assignments should not be made for "readonly" fields not constrained to reference types
+dotnet_diagnostic.S2934.severity = warning
+
+# S2190: Recursion should not be infinite
+dotnet_diagnostic.S2190.severity = warning
+
+# S1862: Related "if/else if" statements should not have the same condition
+dotnet_diagnostic.S1862.severity = warning
+
+# S2184: Results of integer division should not be assigned to floating point variables
+dotnet_diagnostic.S2184.severity = warning
+
+# S2201: Return values from functions without side effects should not be ignored
+dotnet_diagnostic.S2201.severity = warning
+
+# S3449: Right operands of shift operators should be integers
+dotnet_diagnostic.S3449.severity = warning
+
+# S3927: Serialization event handlers should be implemented correctly
+dotnet_diagnostic.S3927.severity = warning
+
+# S2551: Shared resources should not be used for locking
+dotnet_diagnostic.S2551.severity = warning
+
+# S2857: SQL keywords should be delimited by whitespace
+dotnet_diagnostic.S2857.severity = warning
+
+# S3263: Static fields should appear in the order they must be initialized
+dotnet_diagnostic.S3263.severity = warning
+
+# S3464: Type inheritance should not be recursive
+dotnet_diagnostic.S3464.severity = warning
+
+# S3903: Types should be defined in named namespaces
+dotnet_diagnostic.S3903.severity = warning
+
+# S2123: Values should not be uselessly incremented
+dotnet_diagnostic.S2123.severity = warning
+
+# S1656: Variables should not be self-assigned
+dotnet_diagnostic.S1656.severity = warning
+
+# S2306: "async" and "await" should not be used as identifiers
+dotnet_diagnostic.S2306.severity = warning
+
+
+# [Category: Security]
+# S3884: "CoSetProxyBlanket" and "CoInitializeSecurity" should not be used
+dotnet_diagnostic.S3884.severity = warning
+
+# S2115: A secure password should be used when connecting to a database
+dotnet_diagnostic.S2115.severity = warning
+
+# S5547: Cipher algorithms should be robust
+dotnet_diagnostic.S5547.severity = warning
+
+# S3329: Cipher Block Chaining IVs should be unpredictable
+dotnet_diagnostic.S3329.severity = warning
+
+# S5542: Encryption algorithms should be used with secure mode and padding scheme
+dotnet_diagnostic.S5542.severity = warning
+
+# S5445: Insecure temporary file creation methods should not be used
+dotnet_diagnostic.S5445.severity = warning
+
+# S5659: JWT should be signed and verified with strong cipher algorithms
+dotnet_diagnostic.S5659.severity = warning
+
+# S4433: LDAP connections should be authenticated
+dotnet_diagnostic.S4433.severity = warning
+
+# S4211: Members should not have conflicting transparency annotations
+dotnet_diagnostic.S4211.severity = warning
+
+# S4423: Weak SSL/TLS protocols should not be used
+dotnet_diagnostic.S4423.severity = warning
+
+# S2755: XML parsers should not be vulnerable to XXE attacks
+dotnet_diagnostic.S2755.severity = warning
+
+# S2053: Hashes should include an unpredictable salt
+dotnet_diagnostic.S2053.severity = warning
+
+# S4830: Server certificates should be verified during SSL/TLS connections
+dotnet_diagnostic.S4830.severity = warning
+
+# S4426: Cryptographic keys should be robust
+dotnet_diagnostic.S4426.severity = warning
+
+# S5773: Types allowed to be deserialized should be restricted
+dotnet_diagnostic.S5773.severity = warning
+
+
+# [Category: Security Hotspot]
+# S5693: Allowing requests with excessive content length is security-sensitive
+dotnet_diagnostic.S5693.severity = warning
+
+# S4792: Configuring loggers is security-sensitive
+dotnet_diagnostic.S4792.severity = warning
+
+# S3330: Creating cookies without the "HttpOnly" flag is security-sensitive
+dotnet_diagnostic.S3330.severity = warning
+
+# S2092: Creating cookies without the "secure" flag is security-sensitive
+dotnet_diagnostic.S2092.severity = warning
+
+# S4507: Delivering code in production with debug features activated is security-sensitive
+dotnet_diagnostic.S4507.severity = warning
+
+# S5766: Deserializing objects without performing data validation is security-sensitive
+dotnet_diagnostic.S5766.severity = warning
+
+# S5753: Disabling ASP.NET "Request Validation" feature is security-sensitive
+dotnet_diagnostic.S5753.severity = warning
+
+# S4502: Disabling CSRF protections is security-sensitive
+dotnet_diagnostic.S4502.severity = warning
+
+# S5042: Expanding archive files without controlling resource consumption is security-sensitive
+dotnet_diagnostic.S5042.severity = warning
+
+# S2077: Formatting SQL queries is security-sensitive
+dotnet_diagnostic.S2077.severity = warning
+
+# S2068: Hard-coded credentials are security-sensitive
+dotnet_diagnostic.S2068.severity = warning
+
+# S5122: Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
+dotnet_diagnostic.S5122.severity = warning
+
+# S4036: Searching OS commands in PATH is security-sensitive
+dotnet_diagnostic.S4036.severity = warning
+
+# S2612: Setting loose file permissions is security-sensitive
+dotnet_diagnostic.S2612.severity = warning
+
+# S5332: Using clear-text protocols is security-sensitive
+dotnet_diagnostic.S5332.severity = warning
+
+# S1313: Using hardcoded IP addresses is security-sensitive
+dotnet_diagnostic.S1313.severity = warning
+
+# S2257: Using non-standard cryptographic algorithms is security-sensitive
+dotnet_diagnostic.S2257.severity = warning
+
+# S2245: Using pseudorandom number generators (PRNGs) is security-sensitive
+dotnet_diagnostic.S2245.severity = warning
+
+# S5443: Using publicly writable directories is security-sensitive
+dotnet_diagnostic.S5443.severity = warning
+
+# S4790: Using weak hashing algorithms is security-sensitive
+dotnet_diagnostic.S4790.severity = warning
+
+
+# [Category: Code Smell]
+# S3451: "[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant
+dotnet_diagnostic.S3451.severity = warning
+
+# S3447: "[Optional]" should not be used on "ref" or "out" parameters
+dotnet_diagnostic.S3447.severity = warning
+
+# S1155: "Any()" should be used to test for emptiness
+dotnet_diagnostic.S1155.severity = warning
+
+# S2737: "catch" clauses should do more than rethrow
+dotnet_diagnostic.S2737.severity = warning
+
+# S4524: "default" clauses should be first or last
+dotnet_diagnostic.S4524.severity = warning
+
+# S3217: "Explicit" conversions of "foreach" loops should not be used
+dotnet_diagnostic.S3217.severity = warning
+
+# S3971: "GC.SuppressFinalize" should not be called
+dotnet_diagnostic.S3971.severity = warning
+
+# S907: "goto" statement should not be used
+dotnet_diagnostic.S907.severity = warning
+
+# S2692: "IndexOf" checks should not be for positive numbers
+dotnet_diagnostic.S2692.severity = warning
+
+# S3060: "is" should not be used with "this"
+dotnet_diagnostic.S3060.severity = warning
+
+# S1123: "Obsolete" attributes should include explanations
+dotnet_diagnostic.S1123.severity = warning
+
+# S4214: "P/Invoke" methods should not be visible
+dotnet_diagnostic.S4214.severity = warning
+
+# S4061: "params" should be used instead of "varargs"
+dotnet_diagnostic.S4061.severity = warning
+
+# S3262: "params" should be used on overrides
+dotnet_diagnostic.S3262.severity = warning
+
+# S3600: "params" should not be introduced on overrides
+dotnet_diagnostic.S3600.severity = warning
+
+# S3597: "ServiceContract" and "OperationContract" attributes should be used together
+dotnet_diagnostic.S3597.severity = warning
+
+# S3963: "static" fields should be initialized inline
+dotnet_diagnostic.S3963.severity = warning
+
+# S3256: "string.IsNullOrEmpty" should be used
+dotnet_diagnostic.S3256.severity = warning
+
+# S1479: "switch" statements should not have too many "case" clauses
+dotnet_diagnostic.S1479.severity = warning
+
+# S5034: "ValueTask" should be consumed correctly
+dotnet_diagnostic.S5034.severity = warning
+
+# S1264: A "while" loop should be used instead of a "for" loop
+dotnet_diagnostic.S1264.severity = warning
+
+# S3973: A conditionally executed single line should be denoted by indentation
+dotnet_diagnostic.S3973.severity = warning
+
+# S3904: Assemblies should have version information
+dotnet_diagnostic.S3904.severity = warning
+
+# S3415: Assertion arguments should be passed in the correct order
+dotnet_diagnostic.S3415.severity = warning
+
+# S4019: Base class methods should not be hidden
+dotnet_diagnostic.S4019.severity = warning
+
+# S1940: Boolean checks should not be inverted
+dotnet_diagnostic.S1940.severity = warning
+
+# S3236: Caller information arguments should not be provided explicitly
+dotnet_diagnostic.S3236.severity = warning
+
+# S3897: Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
+dotnet_diagnostic.S3897.severity = warning
+
+# S3457: Composite format strings should be used correctly
+dotnet_diagnostic.S3457.severity = warning
+
+# S3972: Conditionals should start on new lines
+dotnet_diagnostic.S3972.severity = warning
+
+# S1116: Empty statements should be removed
+dotnet_diagnostic.S1116.severity = warning
+
+# S3264: Events should be invoked
+dotnet_diagnostic.S3264.severity = warning
+
+# S3445: Exceptions should not be explicitly rethrown
+dotnet_diagnostic.S3445.severity = warning
+
+# S1163: Exceptions should not be thrown in finally blocks
+dotnet_diagnostic.S1163.severity = warning
+
+# S2290: Field-like events should not be virtual
+dotnet_diagnostic.S2290.severity = warning
+
+# S2346: Flags enumerations zero-value members should be named "warning"
+dotnet_diagnostic.S2346.severity = warning
+
+# S3251: Implementations should be provided for "partial" methods
+dotnet_diagnostic.S3251.severity = warning
+
+# S1944: Inappropriate casts should not be made
+dotnet_diagnostic.S1944.severity = warning
+
+# S4015: Inherited member visibility should not be decreased
+dotnet_diagnostic.S4015.severity = warning
+
+# S3444: Interfaces should not simply inherit from base interfaces with colliding members
+dotnet_diagnostic.S3444.severity = warning
+
+# S818: Literal suffixes should be upper case
+dotnet_diagnostic.S818.severity = warning
+
+# S3400: Methods should not return constants
+dotnet_diagnostic.S3400.severity = warning
+
+# S2681: Multiline blocks should be enclosed in curly braces
+dotnet_diagnostic.S2681.severity = warning
+
+# S3169: Multiple "OrderBy" calls should not be used
+dotnet_diagnostic.S3169.severity = warning
+
+# S3261: Namespaces should not be empty
+dotnet_diagnostic.S3261.severity = warning
+
+# S4200: Native methods should be wrapped
+dotnet_diagnostic.S4200.severity = warning
+
+# S1199: Nested code blocks should not be used
+dotnet_diagnostic.S1199.severity = warning
+
+# S4070: Non-flags enums should not be marked with "FlagsAttribute"
+dotnet_diagnostic.S4070.severity = warning
+
+# S3265: Non-flags enums should not be used in bitwise operations
+dotnet_diagnostic.S3265.severity = warning
+
+# S4201: Null checks should not be used with "is"
+dotnet_diagnostic.S4201.severity = warning
+
+# S3966: Objects should not be disposed more than once
+dotnet_diagnostic.S3966.severity = warning
+
+# S2291: Overflow checking should not be disabled for "Enumerable.Sum"
+dotnet_diagnostic.S2291.severity = warning
+
+# S1185: Overriding members should do more than simply call the same member in the base class
+dotnet_diagnostic.S1185.severity = warning
+
+# S2234: Parameters should be passed in the correct order
+dotnet_diagnostic.S2234.severity = warning
+
+# S3450: Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
+dotnet_diagnostic.S3450.severity = warning
+
+# S1905: Redundant casts should not be used
+dotnet_diagnostic.S1905.severity = warning
+
+# S1110: Redundant pairs of parentheses should be removed
+dotnet_diagnostic.S1110.severity = warning
+
+# S2437: Silly bit operations should not be performed
+dotnet_diagnostic.S2437.severity = warning
+
+# S3010: Static fields should not be updated in constructors
+dotnet_diagnostic.S3010.severity = warning
+
+# S4635: String offset-based methods should be preferred for finding substrings from offsets
+dotnet_diagnostic.S4635.severity = warning
+
+# S3998: Threads should not lock on objects with weak identity
+dotnet_diagnostic.S3998.severity = warning
+
+# S1134: Track uses of "FIXME" tags
+dotnet_diagnostic.S1134.severity = warning
+
+# S1135: Track uses of "TODO" tags
+dotnet_diagnostic.S1135.severity = warning
+
+# S1871: Two branches in a conditional structure should not have exactly the same implementation
+dotnet_diagnostic.S1871.severity = warning
+
+# S3443: Type should not be examined on "System.Type" instances
+dotnet_diagnostic.S3443.severity = warning
+
+# S3459: Unassigned members should be removed
+dotnet_diagnostic.S3459.severity = warning
+
+# S3440: Variables should not be checked against the values they're about to be assigned
+dotnet_diagnostic.S3440.severity = warning
+
+# S2479: Whitespace and control characters in string literals should be explicit
+dotnet_diagnostic.S2479.severity = warning
+
+# S2376: Write-only properties should not be used
+dotnet_diagnostic.S2376.severity = warning
+
+# S3442: "abstract" classes should not have "public" constructors
+dotnet_diagnostic.S3442.severity = warning
+
+# S3885: "Assembly.Load" should be used
+dotnet_diagnostic.S3885.severity = warning
+
+# S1210: "Equals" and the comparison operators should be overridden when implementing "IComparable"
+dotnet_diagnostic.S1210.severity = warning
+
+# S1215: "GC.Collect" should not be called
+dotnet_diagnostic.S1215.severity = warning
+
+# S3881: "IDisposable" should be implemented correctly
+dotnet_diagnostic.S3881.severity = warning
+
+# S2971: "IEnumerable" LINQs should be simplified
+dotnet_diagnostic.S2971.severity = warning
+
+# S3925: "ISerializable" should be implemented correctly
+dotnet_diagnostic.S3925.severity = warning
+
+# S4581: "new Guid()" should not be used
+dotnet_diagnostic.S4581.severity = warning
+
+# S3875: "operator==" should not be overloaded on reference types
+dotnet_diagnostic.S3875.severity = warning
+
+# S3237: "value" parameters should be used
+dotnet_diagnostic.S3237.severity = warning
+
+# S1121: Assignments should not be made from within sub-expressions
+dotnet_diagnostic.S1121.severity = warning
+
+# S3376: Attribute, EventArgs, and Exception type names should end with the type being extended
+dotnet_diagnostic.S3376.severity = warning
+
+# S2589: Boolean expressions should not be gratuitous
+dotnet_diagnostic.S2589.severity = warning
+
+# S4035: Classes implementing "IEquatable<T>" should be sealed
+dotnet_diagnostic.S4035.severity = warning
+
+# S3776: Cognitive Complexity of methods should not be too high
+dotnet_diagnostic.S3776.severity = warning
+
+# S1066: Collapsible "if" statements should be merged
+dotnet_diagnostic.S1066.severity = warning
+
+# S1699: Constructors should only call non-overridable methods
+dotnet_diagnostic.S1699.severity = warning
+
+# S2372: Exceptions should not be thrown from property getters
+dotnet_diagnostic.S2372.severity = warning
+
+# S3877: Exceptions should not be thrown from unexpected methods
+dotnet_diagnostic.S3877.severity = warning
+
+# S1104: Fields should not have public accessibility
+dotnet_diagnostic.S1104.severity = warning
+
+# S2933: Fields that are only assigned in the constructor should be "readonly"
+dotnet_diagnostic.S2933.severity = warning
+
+# S112: General exceptions should never be thrown
+dotnet_diagnostic.S112.severity = warning
+
+# S2486: Generic exceptions should not be ignored
+dotnet_diagnostic.S2486.severity = warning
+
+# S3246: Generic type parameters should be co/contravariant when possible
+dotnet_diagnostic.S3246.severity = warning
+
+# S1939: Inheritance list should not be redundant
+dotnet_diagnostic.S1939.severity = warning
+
+# S110: Inheritance tree of classes should not be too deep
+dotnet_diagnostic.S110.severity = warning
+
+# S3218: Inner class members should not shadow outer class "static" or type members
+dotnet_diagnostic.S3218.severity = warning
+
+# S2696: Instance members should not write to "static" fields
+dotnet_diagnostic.S2696.severity = warning
+
+# S3626: Jump statements should not be redundant
+dotnet_diagnostic.S3626.severity = warning
+
+# S1117: Local variables should not shadow class fields
+dotnet_diagnostic.S1117.severity = warning
+
+# S3267: Loops should be simplified with "LINQ" expressions
+dotnet_diagnostic.S3267.severity = warning
+
+# S3604: Member initializer values should not be redundant
+dotnet_diagnostic.S3604.severity = warning
+
+# S3220: Method calls should not resolve ambiguously to overloads with "params"
+dotnet_diagnostic.S3220.severity = warning
+
+# S4136: Method overloads should be grouped together
+dotnet_diagnostic.S4136.severity = warning
+
+# S3427: Method overloads with default parameter values should not overlap 
+dotnet_diagnostic.S3427.severity = warning
+
+# S1006: Method overrides should not change parameter defaults
+dotnet_diagnostic.S1006.severity = warning
+
+# S2953: Methods named "Dispose" should implement "IDisposable.Dispose"
+dotnet_diagnostic.S2953.severity = warning
+
+# S1186: Methods should not be empty
+dotnet_diagnostic.S1186.severity = warning
+
+# S4144: Methods should not have identical implementations
+dotnet_diagnostic.S4144.severity = warning
+
+# S107: Methods should not have too many parameters
+dotnet_diagnostic.S107.severity = warning
+
+# S3241: Methods should not return values that are never used
+dotnet_diagnostic.S3241.severity = warning
+
+# S2386: Mutable fields should not be "public static"
+dotnet_diagnostic.S2386.severity = warning
+
+# S108: Nested blocks of code should not be left empty
+dotnet_diagnostic.S108.severity = warning
+
+# S2223: Non-constant static fields should not be visible
+dotnet_diagnostic.S2223.severity = warning
+
+# S3260: Non-derived "private" classes and records should be "sealed"
+dotnet_diagnostic.S3260.severity = warning
+
+# S927: Parameter names should match base declaration and other partial definitions
+dotnet_diagnostic.S927.severity = warning
+
+# S3928: Parameter names used into ArgumentException constructors should match an existing one 
+dotnet_diagnostic.S3928.severity = warning
+
+# S4457: Parameter validation in "async"/"await" methods should be wrapped
+dotnet_diagnostic.S4457.severity = warning
+
+# S4456: Parameter validation in yielding methods should be wrapped
+dotnet_diagnostic.S4456.severity = warning
+
+# S1450: Private fields only used as local variables in methods should become local variables
+dotnet_diagnostic.S1450.severity = warning
+
+# S2365: Properties should not make collection or array copies
+dotnet_diagnostic.S2365.severity = warning
+
+# S2368: Public methods should not have multidimensional array parameters
+dotnet_diagnostic.S2368.severity = warning
+
+# S3011: Reflection should not be used to increase accessibility of classes, methods, or fields
+dotnet_diagnostic.S3011.severity = warning
+
+# S2219: Runtime type checking should be simplified
+dotnet_diagnostic.S2219.severity = warning
+
+# S125: Sections of code should not be commented out
+dotnet_diagnostic.S125.severity = warning
+
+# S2178: Short-circuit logic should be used in boolean contexts
+dotnet_diagnostic.S2178.severity = warning
+
+# S2743: Static fields should not be used in generic types
+dotnet_diagnostic.S2743.severity = warning
+
+# S1643: Strings should not be concatenated using '+' in a loop
+dotnet_diagnostic.S1643.severity = warning
+
+# S3358: Ternary operators should not be nested
+dotnet_diagnostic.S3358.severity = warning
+
+# S3433: Test method signatures should be correct
+dotnet_diagnostic.S3433.severity = warning
+
+# S2187: TestCases should contain tests
+dotnet_diagnostic.S2187.severity = warning
+
+# S2699: Tests should include assertions
+dotnet_diagnostic.S2699.severity = warning
+
+# S1607: Tests should not be ignored
+dotnet_diagnostic.S1607.severity = warning
+
+# S2292: Trivial properties should be auto-implemented
+dotnet_diagnostic.S2292.severity = warning
+
+# S2436: Types and methods should not have too many generic parameters
+dotnet_diagnostic.S2436.severity = warning
+
+# S101: Types should be named in PascalCase
+dotnet_diagnostic.S101.severity = warning
+
+# S4487: Unread "private" fields should be removed
+dotnet_diagnostic.S4487.severity = warning
+
+# S1854: Unused assignments should be removed
+dotnet_diagnostic.S1854.severity = warning
+
+# S1481: Unused local variables should be removed
+dotnet_diagnostic.S1481.severity = warning
+
+# S1172: Unused method parameters should be removed
+dotnet_diagnostic.S1172.severity = warning
+
+# S1144: Unused private types or members should be removed
+dotnet_diagnostic.S1144.severity = warning
+
+# S2326: Unused type parameters should be removed
+dotnet_diagnostic.S2326.severity = warning
+
+# S1075: URIs should not be hardcoded
+dotnet_diagnostic.S1075.severity = warning
+
+# S1118: Utility classes should not have public constructors
+dotnet_diagnostic.S1118.severity = warning
+
+# S2376: Write-only properties should not be used
+dotnet_diagnostic.S2376.severity = warning
+
+# S1125: Boolean literals should not be redundant
+dotnet_diagnostic.S1125.severity = warning
+
+
+# ===== Inactive SonarLint rules (must be explicitly turned off) =====
+
+# [Category: Bug] (All these are excluded because they're not applicable to our solution)
+# S4428: "PartCreationPolicyAttribute" should be used with "ExportAttribute"
+dotnet_diagnostic.S4428.severity = none
+
+# S4260: "ConstructorArgument" parameters should exist in constructors
+dotnet_diagnostic.S4260.severity = none
+
+# S4277: "Shared" parts should not be created with "new"
+dotnet_diagnostic.S4277.severity = none
+
+# S4159: Classes should implement their "ExportAttribute" interfaces
+dotnet_diagnostic.S4159.severity = none
+
+# S4210: Windows Forms entry points should be marked with STAThread
+dotnet_diagnostic.S4210.severity = none
+
+
+# [Uncategorized]
+# S6287: HTTP responses should not be vulnerable to session fixation
+dotnet_diagnostic.S6287.severity = none
+
+# S6096: Extracting archives should not lead to zip slip vulnerabilities
+dotnet_diagnostic.S6096.severity = none
+
+# S5334: Dynamic code execution should not be vulnerable to injection attacks
+dotnet_diagnostic.S5334.severity = none
+
+# S5146: HTTP request redirections should not be open to forging attacks
+dotnet_diagnostic.S5146.severity = none
+
+# S5135: Deserialization should not be vulnerable to injection attacks
+dotnet_diagnostic.S5135.severity = none
+
+# S5131: Endpoints should not be vulnerable to reflected cross-site scripting (XSS) attacks
+dotnet_diagnostic.S5131.severity = none
+
+# S3649: Database queries should not be vulnerable to injection attacks
+dotnet_diagnostic.S3649.severity = none
+
+# S2091: XPath expressions should not be vulnerable to injection attacks
+dotnet_diagnostic.S2091.severity = none
+
+# S2083: I/O function calls should not be vulnerable to path injection attacks
+dotnet_diagnostic.S2083.severity = none
+
+# S2078: LDAP queries should not be vulnerable to injection attacks
+dotnet_diagnostic.S2078.severity = none
+
+# S2076: OS commands should not be vulnerable to command injection attacks
+dotnet_diagnostic.S2076.severity = none
+
+# S6424: Azure Functions: Restrictions on entity interfaces
+dotnet_diagnostic.S6424.severity = none
+
+# S6422: Calls to "async" methods should not be blocking in Azure Functions
+dotnet_diagnostic.S6422.severity = none
+
+# S2631: Regular expressions should not be vulnerable to Denial of Service attacks
+dotnet_diagnostic.S2631.severity = none
+
+# S2222: Locks should be released
+dotnet_diagnostic.S2222.severity = none
+
+# S5144: Server-side requests should not be vulnerable to forging attacks
+dotnet_diagnostic.S5144.severity = none
+
+# S6350: Constructing arguments of system commands from user input is security-sensitive
+dotnet_diagnostic.S6350.severity = none
+
+# S6420: Reuse client instances rather than creating new ones with each Azure Function invocation
+dotnet_diagnostic.S6420.severity = none
+
+# S6419: Azure Functions should be stateless
+dotnet_diagnostic.S6419.severity = none
+
+# S5883: OS commands should not be vulnerable to argument injection attacks
+dotnet_diagnostic.S5883.severity = none
+
+# S5145: Logging should not be vulnerable to injection attacks
+dotnet_diagnostic.S5145.severity = none
+
+# S2931: Classes with "IDisposable" members should implement "IDisposable"
+dotnet_diagnostic.S2931.severity = none
+
+# S4462: Calls to "async" methods should not be blocking
+dotnet_diagnostic.S4462.severity = none
+
+# S2387: Child class fields should not shadow parent class fields
+dotnet_diagnostic.S2387.severity = none
+
+# S1451: Track lack of copyright and license headers
+dotnet_diagnostic.S1451.severity = none
+
+# S1147: Exit methods should not be called
+dotnet_diagnostic.S1147.severity = none
+
+# S2952: Classes should "Dispose" of members from the classes' own "Dispose" methods
+dotnet_diagnostic.S2952.severity = none
+
+# S4829: Reading the Standard Input is security-sensitive
+dotnet_diagnostic.S4829.severity = none
+
+# S4823: Using command line arguments is security-sensitive
+dotnet_diagnostic.S4823.severity = none
+
+# S4818: Using Sockets is security-sensitive
+dotnet_diagnostic.S4818.severity = none
+
+# S4787: Encrypting data is security-sensitive
+dotnet_diagnostic.S4787.severity = none
+
+# S4784: Using regular expressions is security-sensitive
+dotnet_diagnostic.S4784.severity = none
+
+# S4039: Interface methods should be callable by derived types
+dotnet_diagnostic.S4039.severity = none
+
+# S4025: Child class fields should not differ from parent class fields only by capitalization
+dotnet_diagnostic.S4025.severity = none
+
+# S4000: Pointers to unmanaged memory should not be visible
+dotnet_diagnostic.S4000.severity = none
+
+# S3937: Number patterns should be regular
+dotnet_diagnostic.S3937.severity = none
+
+# S3874: "out" and "ref" parameters should not be used
+dotnet_diagnostic.S3874.severity = none
+
+# S3353: Unchanged local variables should be "const"
+dotnet_diagnostic.S3353.severity = none
+
+# S3216: "ConfigureAwait(false)" should be used
+dotnet_diagnostic.S3216.severity = none
+
+# S3215: "interface" instances should not be cast to concrete types
+dotnet_diagnostic.S3215.severity = none
+
+# S2701: Literal boolean values should not be used in assertions
+dotnet_diagnostic.S2701.severity = none
+
+# S2360: Optional parameters should not be used
+dotnet_diagnostic.S2360.severity = none
+
+# S2339: Public constant members should not be used
+dotnet_diagnostic.S2339.severity = none
+
+# S2330: Array covariance should not be used
+dotnet_diagnostic.S2330.severity = none
+
+# S2302: "nameof" should be used
+dotnet_diagnostic.S2302.severity = none
+
+# S2197: Modulus results should not be checked for direct equality
+dotnet_diagnostic.S2197.severity = none
+
+# S1994: "for" loop increment clauses should modify the loops' counters
+dotnet_diagnostic.S1994.severity = none
+
+# S1821: "switch" statements should not be nested
+dotnet_diagnostic.S1821.severity = none
+
+# S1541: Methods and properties should not be too complex
+dotnet_diagnostic.S1541.severity = none
+
+# S134: Control flow statements "if", "switch", "for", "foreach", "while", "do" and "try" should not be nested too deeply
+dotnet_diagnostic.S134.severity = none
+
+# S131: "switch/Select" statements should contain a "default/Case Else" clauses
+dotnet_diagnostic.S131.severity = none
+
+# S126: "if ... else if" constructs should end with "else" clauses
+dotnet_diagnostic.S126.severity = none
+
+# S121: Control structures should use curly braces
+dotnet_diagnostic.S121.severity = none
+
+# S1067: Expressions should not be too complex
+dotnet_diagnostic.S1067.severity = none
+
+# S4564: ASP.NET HTTP request validation feature should not be disabled
+dotnet_diagnostic.S4564.severity = none
+
+# S4212: Serialization constructors should be secured
+dotnet_diagnostic.S4212.severity = none
+
+# S3949: Calculations should not overflow
+dotnet_diagnostic.S3949.severity = none
+
+# S1244: Floating point numbers should not be tested for equality
+dotnet_diagnostic.S1244.severity = none
+
+# S881: Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
+dotnet_diagnostic.S881.severity = none
+
+# S6423: Azure Functions should log all failures
+dotnet_diagnostic.S6423.severity = none
+
+# S6421: Azure Functions should use Structured Error Handling
+dotnet_diagnostic.S6421.severity = none
+
+# S6354: Use a testable date/time provider
+dotnet_diagnostic.S6354.severity = none
+
+# S4059: Property names should not match get methods
+dotnet_diagnostic.S4059.severity = none
+
+# S4057: Locales should be set for data types
+dotnet_diagnostic.S4057.severity = none
+
+# S4055: Literals should not be passed as localized parameters
+dotnet_diagnostic.S4055.severity = none
+
+# S4050: Operators should be overloaded consistently
+dotnet_diagnostic.S4050.severity = none
+
+# S4017: Method signatures should not contain nested generic types
+dotnet_diagnostic.S4017.severity = none
+
+# S4016: Enumeration members should not be named "Reserved"
+dotnet_diagnostic.S4016.severity = none
+
+# S4005: "System.Uri" arguments should be used instead of strings
+dotnet_diagnostic.S4005.severity = none
+
+# S4004: Collection properties should be readonly
+dotnet_diagnostic.S4004.severity = none
+
+# S4002: Disposable types should declare finalizers
+dotnet_diagnostic.S4002.severity = none
+
+# S3997: String URI overloads should call "System.Uri" overloads
+dotnet_diagnostic.S3997.severity = none
+
+# S3996: URI properties should not be strings
+dotnet_diagnostic.S3996.severity = none
+
+# S3995: URI return values should not be strings
+dotnet_diagnostic.S3995.severity = none
+
+# S3994: URI Parameters should not be strings
+dotnet_diagnostic.S3994.severity = none
+
+# S3993: Custom attributes should be marked with "System.AttributeUsageAttribute"
+dotnet_diagnostic.S3993.severity = none
+
+# S3992: Assemblies should explicitly specify COM visibility
+dotnet_diagnostic.S3992.severity = none
+
+# S3990: Assemblies should be marked as CLS compliant
+dotnet_diagnostic.S3990.severity = none
+
+# S3956: "Generic.List" instances should not be part of public APIs
+dotnet_diagnostic.S3956.severity = none
+
+# S3909: Collections should implement the generic interface
+dotnet_diagnostic.S3909.severity = none
+
+# S3908: Generic event handlers should be used
+dotnet_diagnostic.S3908.severity = none
+
+# S3906: Event Handlers should have the correct signature
+dotnet_diagnostic.S3906.severity = none
+
+# S3902: "Assembly.GetExecutingAssembly" should not be called
+dotnet_diagnostic.S3902.severity = none
+
+# S3900: Arguments of public methods should be validated against null
+dotnet_diagnostic.S3900.severity = none
+
+# S3898: Value types should implement "IEquatable<T>"
+dotnet_diagnostic.S3898.severity = none
+
+# S3880: Finalizers should not be empty
+dotnet_diagnostic.S3880.severity = none
+
+# S3431: "[ExpectedException]" should not be used
+dotnet_diagnostic.S3431.severity = none
+
+# S3366: "this" should not be exposed from constructors
+dotnet_diagnostic.S3366.severity = none
+
+# S3059: Types should not have members with visibility set higher than the type's visibility
+dotnet_diagnostic.S3059.severity = none
+
+# S2357: Fields should be private
+dotnet_diagnostic.S2357.severity = none
+
+# S2327: "try" statements with identical "catch" and/or "finally" blocks should be merged
+dotnet_diagnostic.S2327.severity = none
+
+# S1696: NullReferenceException should not be caught
+dotnet_diagnostic.S1696.severity = none
+
+# S138: Functions should not have too many lines of code
+dotnet_diagnostic.S138.severity = none
+
+# S127: "for" loop stop conditions should be invariant
+dotnet_diagnostic.S127.severity = none
+
+# S122: Statements should be on separate lines
+dotnet_diagnostic.S122.severity = none
+
+# S1200: Classes should not be coupled to too many other classes (Single Responsibility Principle)
+dotnet_diagnostic.S1200.severity = none
+
+# S1151: "switch case" clauses should not have too many lines of code
+dotnet_diagnostic.S1151.severity = none
+
+# S109: Magic numbers should not be used
+dotnet_diagnostic.S109.severity = none
+
+# S106: Standard outputs should not be used directly to log anything
+dotnet_diagnostic.S106.severity = none
+
+# S104: Files should not have too many lines of code
+dotnet_diagnostic.S104.severity = none
+
+# S103: Lines should not be too long
+dotnet_diagnostic.S103.severity = none
+
+# S5167: HTTP response headers should not be vulnerable to injection attacks
+dotnet_diagnostic.S5167.severity = none
+
+# S2228: Console logging should not be used
+dotnet_diagnostic.S2228.severity = none
+
+# S2955: Generic parameters not constrained to reference types should not be compared to "null"
+dotnet_diagnostic.S2955.severity = none
+
+# S2674: The length returned from a stream read should be checked
+dotnet_diagnostic.S2674.severity = none
+
+# S1226: Method parameters, caught exceptions and foreach variables' initial values should not be ignored
+dotnet_diagnostic.S1226.severity = none
+
+# S4834: Controlling permissions is security-sensitive
+dotnet_diagnostic.S4834.severity = none
+
+# S2255: Writing cookies is security-sensitive
+dotnet_diagnostic.S2255.severity = none
+
+# S4261: Methods should be named according to their synchronicities
+dotnet_diagnostic.S4261.severity = none
+
+# S4226: Extensions should be in separate namespaces
+dotnet_diagnostic.S4226.severity = none
+
+# S4225: Extension methods should not extend "object"
+dotnet_diagnostic.S4225.severity = none
+
+# S4069: Operator overloads should have named alternatives
+dotnet_diagnostic.S4069.severity = none
+
+# S4060: Non-abstract attributes should be sealed
+dotnet_diagnostic.S4060.severity = none
+
+# S4058: Overloads with a "StringComparison" parameter should be used
+dotnet_diagnostic.S4058.severity = none
+
+# S4056: Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
+dotnet_diagnostic.S4056.severity = none
+
+# S4052: Types should not extend outdated base types
+dotnet_diagnostic.S4052.severity = none
+
+# S4049: Properties should be preferred
+dotnet_diagnostic.S4049.severity = none
+
+# S4047: Generics should be used when appropriate
+dotnet_diagnostic.S4047.severity = none
+
+# S4041: Type names should not match namespaces
+dotnet_diagnostic.S4041.severity = none
+
+# S4040: Strings should be normalized to uppercase
+dotnet_diagnostic.S4040.severity = none
+
+# S4027: Exceptions should provide standard constructors
+dotnet_diagnostic.S4027.severity = none
+
+# S4026: Assemblies should be marked with "NeutralResourcesLanguageAttribute"
+dotnet_diagnostic.S4026.severity = none
+
+# S4023: Interfaces should not be empty
+dotnet_diagnostic.S4023.severity = none
+
+# S4022: Enumerations should have "Int32" storage
+dotnet_diagnostic.S4022.severity = none
+
+# S4018: Generic methods should provide type parameters
+dotnet_diagnostic.S4018.severity = none
+
+# S3967: Multidimensional arrays should not be used
+dotnet_diagnostic.S3967.severity = none
+
+# S3962: "static readonly" constants should be "const" instead
+dotnet_diagnostic.S3962.severity = none
+
+# S3876: Strings or integral types should be used for indexers
+dotnet_diagnostic.S3876.severity = none
+
+# S3872: Parameter names should not duplicate the names of their methods
+dotnet_diagnostic.S3872.severity = none
+
+# S3717: Track use of "NotImplementedException"
+dotnet_diagnostic.S3717.severity = none
+
+# S3532: Empty "default" clauses should be removed
+dotnet_diagnostic.S3532.severity = none
+
+# S3441: Redundant property names should be omitted in anonymous classes
+dotnet_diagnostic.S3441.severity = none
+
+# S3257: Declarations and initializations should be as concise as possible
+dotnet_diagnostic.S3257.severity = none
+
+# S3254: Default parameter values should not be passed as arguments
+dotnet_diagnostic.S3254.severity = none
+
+# S3253: Constructor and destructor declarations should not be redundant
+dotnet_diagnostic.S3253.severity = none
+
+# S3242: Method parameters should be declared with base types
+dotnet_diagnostic.S3242.severity = none
+
+# S3240: The simplest possible condition syntax should be used
+dotnet_diagnostic.S3240.severity = none
+
+# S3235: Redundant parentheses should not be used
+dotnet_diagnostic.S3235.severity = none
+
+# S3234: "GC.SuppressFinalize" should not be invoked for types without destructors
+dotnet_diagnostic.S3234.severity = none
+
+# S3052: Members should not be initialized to default values
+dotnet_diagnostic.S3052.severity = none
+
+# S2760: Sequential tests should not check the same condition
+dotnet_diagnostic.S2760.severity = none
+
+# S2333: Redundant modifiers should not be used
+dotnet_diagnostic.S2333.severity = none
+
+# S2325: Methods and properties that don't access instance data should be static
+dotnet_diagnostic.S2325.severity = none
+
+# S2221: "Exception" should not be caught when not required by called methods
+dotnet_diagnostic.S2221.severity = none
+
+# S2156: "sealed" classes should not have "protected" members
+dotnet_diagnostic.S2156.severity = none
+
+# S2148: Underscores should be used to make large numbers readable
+dotnet_diagnostic.S2148.severity = none
+
+# S1858: "ToString()" calls should not be redundant
+dotnet_diagnostic.S1858.severity = none
+
+# S1698: "=" should not be used when "Equals" is overridden
+dotnet_diagnostic.S1698.severity = none
+
+# S1694: An abstract class should have both abstract and concrete methods
+dotnet_diagnostic.S1694.severity = none
+
+# S1659: Multiple variables should not be declared on the same line
+dotnet_diagnostic.S1659.severity = none
+
+# S1449: Culture should be specified for "string" operations
+dotnet_diagnostic.S1449.severity = none
+
+# S1301: "switch" statements should have at least 3 "case" clauses
+dotnet_diagnostic.S1301.severity = none
+
+# S1227: break statements should not be used except for switch cases
+dotnet_diagnostic.S1227.severity = none
+
+# S1192: String literals should not be duplicated
+dotnet_diagnostic.S1192.severity = none
+
+# S113: Files should contain an empty newline at the end
+dotnet_diagnostic.S113.severity = none
+
+# S1128: Unused "using" should be removed
+dotnet_diagnostic.S1128.severity = none
+
+# S1109: A close curly brace should be located at the beginning of a line
+dotnet_diagnostic.S1109.severity = none
+
+# S105: Tabulation characters should not be used
+dotnet_diagnostic.S105.severity = none
+
+# S100: Methods and properties should be named in PascalCase
+dotnet_diagnostic.S100.severity = none
+
+# S1309: Track uses of in-source issue suppressions
+dotnet_diagnostic.S1309.severity = none

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+  <ItemGroup Label="StaticCodeAnalysis">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.41.0.50478">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/README.md
+++ b/README.md
@@ -473,19 +473,20 @@ Algolia provides [autocomplete](https://www.algolia.com/doc/ui-libraries/autocom
 }
 ```
 
-4. Add a script near the end of the `<body>` which loads your Algolia index. Be sure to use your __Search API Key__ which is public, and _not_ your __Admin API Key__!
+4. Add a script near the end of the `<body>` which loads your Algolia index. Be sure to use your __Search API Key__ which is public, and _not_ your __Admin API Key__! Please include the following custom user agent, with the version of the integration you are using:
 
 ```js
 <script type="text/javascript">
-    var client = algoliasearch('@algoliaOptions.ApplicationId', '@algoliaOptions.SearchKey');
-    var index = client.initIndex('@AlgoliaSiteSearchModel.IndexName');
+    const client = algoliasearch('@algoliaOptions.ApplicationId', '@algoliaOptions.SearchKey');
+    client.addAlgoliaAgent('Kentico Xperience Integration', '4.0.0');
+    const index = client.initIndex('@AlgoliaSiteSearchModel.IndexName');
 </script>
 ```
 
 5. Initialize the autocomplete search box, then create a handler for when users click on autocomplete suggestions, and when the _Enter_ button is used:
 
 ```js
-var autocompleteBox = autocomplete('#search-input', {hint: false}, [
+const autocompleteBox = autocomplete('#search-input', {hint: false}, [
 {
     source: autocomplete.sources.hits(index, {hitsPerPage: 5}),
     displayKey: 'DocumentName' // The Algolia attribute used to display the title of a suggestion
@@ -497,7 +498,7 @@ var autocompleteBox = autocomplete('#search-input', {hint: false}, [
 document.querySelector("#search-input").addEventListener("keyup", (e) => {
 	if (e.key === 'Enter') {
         // Navigate to search results page when Enter is pressed
-        var searchText = document.querySelector("#search-input").value;
+        const searchText = document.querySelector("#search-input").value;
         window.location = '@(Url.Action("Index", "Search"))?searchtext=' + searchText;
     }
 });
@@ -1089,6 +1090,7 @@ endpoints.MapControllerRoute(
 2. Create the _Index.cshtml_ view for your controller with the basic layout and stylesheet references. Load your Algolia settings for use later:
 
 ```cshtml
+@using Kentico.Xperience.AlgoliaSearch.Models
 @using Microsoft.Extensions.Options
 @inject IOptions<AlgoliaOptions> options
 
@@ -1122,16 +1124,18 @@ endpoints.MapControllerRoute(
 </div>
 ```
 
-3. At the bottom of your view, add a `scripts` section which loads the InstantSearch.js scripts, initializes the search widget, three faceting widgets, the results widget, and pagination widget:
+3. At the bottom of your view, add a `scripts` section which loads the InstantSearch.js scripts, initializes the search widget, three faceting widgets, the results widget, and pagination widget. Please include the following custom user agent, with the version of the integration you are using:
 
 ```cshtml
 @section scripts {
     <script src="https://cdn.jsdelivr.net/npm/algoliasearch@4/dist/algoliasearch-lite.umd.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/instantsearch.js@4"></script>
     <script type="text/javascript">
+        const client = algoliasearch('@algoliaOptions.ApplicationId', '@algoliaOptions.SearchKey');
+        client.addAlgoliaAgent('Kentico Xperience Integration', '4.0.0');
         const search = instantsearch({
           indexName: '@AlgoliaSiteSearchModel.IndexName',
-          searchClient: algoliasearch('@algoliaOptions.ApplicationId', '@algoliaOptions.SearchKey'),
+          searchClient: client
         });
 
         search.addWidgets([

--- a/src/AlgoliaQueueWorker.cs
+++ b/src/AlgoliaQueueWorker.cs
@@ -16,7 +16,7 @@ namespace Kentico.Xperience.AlgoliaSearch
     /// </summary>
     public class AlgoliaQueueWorker : ThreadQueueWorker<AlgoliaQueueItem, AlgoliaQueueWorker>
     {
-        private IAlgoliaIndexingService algoliaIndexingService;
+        private readonly IAlgoliaIndexingService algoliaIndexingService;
 
 
         protected override int DefaultInterval => 10000;

--- a/src/Kentico.Xperience.AlgoliaSearch.csproj
+++ b/src/Kentico.Xperience.AlgoliaSearch.csproj
@@ -9,7 +9,7 @@
 	<PropertyGroup>
 		<Title>Xperience Algolia Search</Title>
 		<PackageId>Kentico.Xperience.AlgoliaSearch</PackageId>
-		<Version>3.1.0</Version>
+		<Version>4.0.0</Version>
 		<Authors>Kentico Software</Authors>
 		<Company>Kentico Software</Company>
 		<PackageIcon>icon.png</PackageIcon>

--- a/src/Models/AlgoliaIndex.cs
+++ b/src/Models/AlgoliaIndex.cs
@@ -9,10 +9,19 @@ namespace Kentico.Xperience.AlgoliaSearch.Models
     public class AlgoliaIndex
     {
         /// <summary>
-        /// The name of the attribute used for Algolia de-duplication. See
-        /// <see href="https://www.algolia.com/doc/guides/sending-and-managing-data/prepare-your-data/how-to/indexing-long-documents/"/>.
+        /// The name of the attribute used for Algolia de-duplication.
         /// </summary>
         public string DistinctAttribute
+        {
+            get;
+            set;
+        }
+
+
+        /// <summary>
+        /// The distinction level.
+        /// </summary>
+        public int DistinctLevel
         {
             get;
             set;

--- a/src/Models/AlgoliaIndex.cs
+++ b/src/Models/AlgoliaIndex.cs
@@ -9,21 +9,11 @@ namespace Kentico.Xperience.AlgoliaSearch.Models
     public class AlgoliaIndex
     {
         /// <summary>
-        /// The name of the attribute used for Algolia de-duplication.
+        /// The distinct and de-duplication settings for the Algolia index.
         /// </summary>
-        public string DistinctAttribute
+        public DistinctOptions DistinctOptions
         {
-            get;
-            set;
-        }
-
-
-        /// <summary>
-        /// The distinction level.
-        /// </summary>
-        public int DistinctLevel
-        {
-            get;
+            get; 
             set;
         }
 

--- a/src/Models/AlgoliaIndex.cs
+++ b/src/Models/AlgoliaIndex.cs
@@ -9,6 +9,17 @@ namespace Kentico.Xperience.AlgoliaSearch.Models
     public class AlgoliaIndex
     {
         /// <summary>
+        /// The name of the attribute used for Algolia de-duplication. See
+        /// <see href="https://www.algolia.com/doc/guides/sending-and-managing-data/prepare-your-data/how-to/indexing-long-documents/"/>.
+        /// </summary>
+        public string DistinctAttribute
+        {
+            get;
+            set;
+        }
+
+
+        /// <summary>
         /// The type of the class which extends <see cref="AlgoliaSearchModel"/>.
         /// </summary>
         public Type Type

--- a/src/Models/AlgoliaQueueItem.cs
+++ b/src/Models/AlgoliaQueueItem.cs
@@ -19,10 +19,9 @@ namespace Kentico.Xperience.AlgoliaSearch.Models
 
 
         /// <summary>
-        /// True if the <see cref="Node"/> was recently deleted and should be removed
-        /// from the Algolia index.
+        /// True if the <see cref="Node"/> data should be removed from the Algolia index.
         /// </summary>
-        public bool Deleted
+        public bool Delete
         {
             get;
             set;

--- a/src/Models/AlgoliaSearchModel.cs
+++ b/src/Models/AlgoliaSearchModel.cs
@@ -92,10 +92,9 @@ namespace Kentico.Xperience.AlgoliaSearch.Models
 
         /// <summary>
         /// Called when indexing a <see cref="TreeNode"/> if the <see cref="AlgoliaIndex"/> was registered
-        /// with a <see cref="AlgoliaIndex.DistinctAttribute"/> and <see cref="AlgoliaIndex.DistinctLevel"/>.
-        /// This method can be used to split one large Algolia record into multiple, smaller records.
+        /// with <see cref="DistinctOptions"/>. This method can be used to split one large Algolia record into
+        /// multiple, smaller records.
         /// </summary>
-        /// <remarks>See <see href="https://www.algolia.com/doc/guides/sending-and-managing-data/prepare-your-data/how-to/indexing-long-documents/"/>.</remarks>
         /// <param name="originalData">The node's data before being split into smaller objects.</param>
         /// <returns>One or more <see cref="JObject"/>s representing the data of the node.</returns>
         public virtual IEnumerable<JObject> SplitData(JObject originalData)

--- a/src/Models/AlgoliaSearchModel.cs
+++ b/src/Models/AlgoliaSearchModel.cs
@@ -2,6 +2,10 @@
 
 using Kentico.Xperience.AlgoliaSearch.Attributes;
 
+using Newtonsoft.Json.Linq;
+
+using System.Collections.Generic;
+
 namespace Kentico.Xperience.AlgoliaSearch.Models
 {
     /// <summary>
@@ -83,6 +87,20 @@ namespace Kentico.Xperience.AlgoliaSearch.Models
         public virtual object OnIndexingProperty(TreeNode node, string propertyName, string usedColumn, object foundValue)
         {
             return foundValue;
+        }
+
+
+        /// <summary>
+        /// Called when indexing a <see cref="TreeNode"/> if the <see cref="AlgoliaIndex"/> was registered
+        /// with a <see cref="AlgoliaIndex.DistinctAttribute"/> and <see cref="AlgoliaIndex.DistinctLevel"/>.
+        /// This method can be used to split one large Algolia record into multiple, smaller records.
+        /// </summary>
+        /// <remarks>See <see href="https://www.algolia.com/doc/guides/sending-and-managing-data/prepare-your-data/how-to/indexing-long-documents/"/>.</remarks>
+        /// <param name="originalData">The node's data before being split into smaller objects.</param>
+        /// <returns>One or more <see cref="JObject"/>s representing the data of the node.</returns>
+        public virtual IEnumerable<JObject> SplitData(JObject originalData)
+        {
+            return new JObject[] { originalData };
         }
     }
 }

--- a/src/Models/DistinctOptions.cs
+++ b/src/Models/DistinctOptions.cs
@@ -1,0 +1,45 @@
+﻿using System;
+
+namespace Kentico.Xperience.AlgoliaSearch.Models
+{
+    /// <summary>
+    /// Represents the distinct and de-duplication settings for the Algolia index.
+    /// </summary>
+    /// <remarks>See <see href="https://www.algolia.com/doc/guides/sending-and-managing-data/prepare-your-data/how-to/indexing-long-documents/"/>.</remarks>
+    public class DistinctOptions
+    {
+        /// <summary>
+        /// The name of the attribute used for Algolia de-duplication.
+        /// </summary>
+        public string DistinctAttribute
+        {
+            get;
+        }
+
+
+        /// <summary>
+        /// The distinction level.
+        /// </summary>
+        public int DistinctLevel
+        {
+            get;
+        }
+
+
+        public DistinctOptions(string distinctAttribute, int distinctLevel)
+        {
+            if (String.IsNullOrEmpty(distinctAttribute))
+            {
+                throw new ArgumentNullException(nameof(distinctAttribute));
+            }
+
+            if (distinctLevel <= 0)
+            {
+                throw new InvalidOperationException("Distinct level must be greater than zero.");
+            }
+
+            DistinctAttribute = distinctAttribute;
+            DistinctLevel = distinctLevel;
+        }
+    }
+}

--- a/src/Services/IAlgoliaIndexRegister.cs
+++ b/src/Services/IAlgoliaIndexRegister.cs
@@ -17,8 +17,9 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
         /// <param name="indexName">The code name of the Algolia index.</param>
         /// <param name="siteNames">The code names of the sites whose pages will be included in the index.
         /// If empty, all sites are included.</param>
+        /// <param name="distinctAttribute">The name of the attribute used for Algolia de-duplication.</param>
         /// <returns>The <see cref="IAlgoliaRegistrationService"/> for chaining.</returns>
-        IAlgoliaIndexRegister Add<TModel>(string indexName, IEnumerable<string> siteNames = null) where TModel : AlgoliaSearchModel;
+        IAlgoliaIndexRegister Add<TModel>(string indexName, IEnumerable<string> siteNames = null, string distinctAttribute = null) where TModel : AlgoliaSearchModel;
 
 
         /// <summary>

--- a/src/Services/IAlgoliaIndexRegister.cs
+++ b/src/Services/IAlgoliaIndexRegister.cs
@@ -17,10 +17,9 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
         /// <param name="indexName">The code name of the Algolia index.</param>
         /// <param name="siteNames">The code names of the sites whose pages will be included in the index.
         /// If empty, all sites are included.</param>
-        /// <param name="distinctAttribute">The name of the attribute used for Algolia de-duplication.</param>
-        /// <param name="distinctLevel">The distinction level.</param>
+        /// <param name="distinctOptions">The distinct options of the index.</param>
         /// <returns>The <see cref="IAlgoliaRegistrationService"/> for chaining.</returns>
-        IAlgoliaIndexRegister Add<TModel>(string indexName, IEnumerable<string> siteNames = null, string distinctAttribute = null, int distinctLevel = 0) where TModel : AlgoliaSearchModel;
+        IAlgoliaIndexRegister Add<TModel>(string indexName, IEnumerable<string> siteNames = null, DistinctOptions distinctOptions = null) where TModel : AlgoliaSearchModel;
 
 
         /// <summary>

--- a/src/Services/IAlgoliaIndexRegister.cs
+++ b/src/Services/IAlgoliaIndexRegister.cs
@@ -18,8 +18,9 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
         /// <param name="siteNames">The code names of the sites whose pages will be included in the index.
         /// If empty, all sites are included.</param>
         /// <param name="distinctAttribute">The name of the attribute used for Algolia de-duplication.</param>
+        /// <param name="distinctLevel">The distinction level.</param>
         /// <returns>The <see cref="IAlgoliaRegistrationService"/> for chaining.</returns>
-        IAlgoliaIndexRegister Add<TModel>(string indexName, IEnumerable<string> siteNames = null, string distinctAttribute = null) where TModel : AlgoliaSearchModel;
+        IAlgoliaIndexRegister Add<TModel>(string indexName, IEnumerable<string> siteNames = null, string distinctAttribute = null, int distinctLevel = 0) where TModel : AlgoliaSearchModel;
 
 
         /// <summary>

--- a/src/Services/IAlgoliaIndexingService.cs
+++ b/src/Services/IAlgoliaIndexingService.cs
@@ -27,16 +27,16 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
 
 
         /// <summary>
-        /// Gets a dynamic <see cref="JObject"/> containing the properties of the Algolia
+        /// Gets dynamic <see cref="JObject"/>s containing the properties of the Algolia
         /// search model and base class <see cref="AlgoliaSearchModel"/>, populated with data
         /// from the <paramref name="node"/>.
         /// </summary>
         /// <param name="node">The <see cref="TreeNode"/> being indexed.</param>
-        /// <param name="searchModelType">The class of the Algolia search model.</param>
-        /// <returns>A <see cref="JObject"/> with its properties and values set.</returns>
+        /// <param name="algoliaIndex">The Algolia index which includes the <paramref name="node"/>.</param>
+        /// <returns>One or more <see cref="JObject"/>s representing the data of the <paramref name="node"/>.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="node"/> or
-        /// <paramref name="searchModelType"/> are null.</exception>
-        JObject GetTreeNodeData(TreeNode node, Type searchModelType);
+        /// <paramref name="algoliaIndex"/> are null.</exception>
+        IEnumerable<JObject> GetTreeNodeData(TreeNode node, AlgoliaIndex algoliaIndex);
 
 
         /// <summary>

--- a/src/Services/IAlgoliaIndexingService.cs
+++ b/src/Services/IAlgoliaIndexingService.cs
@@ -21,9 +21,8 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
         /// </summary>
         /// <remarks>Logs an error if there are issues loading indexed columns.</remarks>
         /// <param name="node">The <see cref="TreeNode"/> that triggered the event.</param>
-        /// <param name="wasDeleted">True if the <paramref name="node"/> was deleted.</param>
-        /// <param name="isNew">True if the <paramref name="node"/> was created.</param>
-        void EnqueueAlgoliaItems(TreeNode node, bool wasDeleted, bool isNew);
+        /// <param name="eventName">The name of the Xperience event that was triggered.</param>
+        void EnqueueAlgoliaItems(TreeNode node, string eventName);
 
 
         /// <summary>

--- a/src/Services/IAlgoliaRegistrationService.cs
+++ b/src/Services/IAlgoliaRegistrationService.cs
@@ -74,15 +74,12 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
 
 
         /// <summary>
-        /// Stores an <see cref="AlgoliaIndex"/> in memory based on the provided parameters. Also calls
+        /// Stores the provided <see cref="AlgoliaIndex"/> in memory. Also calls
         /// <see cref="SearchIndex.SetSettings"/> to initialize the Algolia index's configuration
-        /// based on the attributes defined in the <paramref name="searchModel"/>.
+        /// based on the attributes defined in the <see cref="AlgoliaIndex.Type"/>.
         /// </summary>
-        /// <param name="searchModel">The type of the class which extends <see cref="AlgoliaSearchModel"/>.</param>
-        /// <param name="indexName">The code name of the Algolia index.</param>
-        /// <param name="siteNames">The code names of the sites whose pages will be included in the index.
-        /// If empty, all sites are included.</param>
+        /// <param name="algoliaIndex">The Algolia index definition.</param>
         /// <remarks>Logs an error if the index settings cannot be loaded.</remarks>
-        void RegisterIndex(Type searchModel, string indexName, IEnumerable<string> siteNames = null);
+        void RegisterIndex(AlgoliaIndex algoliaIndex);
     }
 }

--- a/src/Services/Implementations/DefaultAlgoliaConnection.cs
+++ b/src/Services/Implementations/DefaultAlgoliaConnection.cs
@@ -151,7 +151,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
                 {
                     IndexName = algoliaIndex.IndexName,
                     Node = node,
-                    Deleted = false
+                    Delete = false
                 }
             ));
         }

--- a/src/Services/Implementations/DefaultAlgoliaConnection.cs
+++ b/src/Services/Implementations/DefaultAlgoliaConnection.cs
@@ -25,7 +25,6 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
     {
         private ISearchIndex searchIndex;
         private AlgoliaIndex algoliaIndex;
-        private readonly ISearchClient searchClient;
         private readonly IEventLogService eventLogService;
         private readonly IAlgoliaIndexService algoliaIndexService;
         private readonly IAlgoliaRegistrationService algoliaRegistrationService;
@@ -34,12 +33,10 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultAlgoliaConnection"/> class.
         /// </summary>
-        public DefaultAlgoliaConnection(ISearchClient searchClient,
-            IEventLogService eventLogService,
+        public DefaultAlgoliaConnection(IEventLogService eventLogService,
             IAlgoliaIndexService algoliaIndexService,
             IAlgoliaRegistrationService algoliaRegistrationService)
         {
-            this.searchClient = searchClient;
             this.eventLogService = eventLogService;
             this.algoliaIndexService = algoliaIndexService;
             this.algoliaRegistrationService = algoliaRegistrationService;
@@ -66,7 +63,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
         public int DeleteRecords(IEnumerable<string> objectIds)
         {
             var deletedCount = 0;
-            if (objectIds == null || objectIds.Count() == 0)
+            if (objectIds == null || !objectIds.Any())
             {
                 return 0;
             }
@@ -84,7 +81,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
         public int UpsertRecords(IEnumerable<JObject> dataObjects)
         {
             var upsertedCount = 0;
-            if (dataObjects == null || dataObjects.Count() == 0)
+            if (dataObjects == null || !dataObjects.Any())
             {
                 return 0;
             }
@@ -135,7 +132,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
                     query.Culture(includedPathAttribute.Cultures);
                 }
 
-                if (algoliaIndex.SiteNames != null && algoliaIndex.SiteNames.Count() > 0)
+                if (algoliaIndex.SiteNames != null && algoliaIndex.SiteNames.Any())
                 {
                     foreach (var site in algoliaIndex.SiteNames)
                     {

--- a/src/Services/Implementations/DefaultAlgoliaIndexRegister.cs
+++ b/src/Services/Implementations/DefaultAlgoliaIndexRegister.cs
@@ -13,13 +13,14 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
         private readonly Stack<AlgoliaIndex> indexes = new Stack<AlgoliaIndex>();
 
 
-        public IAlgoliaIndexRegister Add<TModel>(string indexName, IEnumerable<string> siteNames = null) where TModel : AlgoliaSearchModel
+        public IAlgoliaIndexRegister Add<TModel>(string indexName, IEnumerable<string> siteNames = null, string distinctAttribute = null) where TModel : AlgoliaSearchModel
         {
             indexes.Push(new AlgoliaIndex
             {
                 IndexName = indexName,
                 Type = typeof(TModel),
-                SiteNames = siteNames
+                SiteNames = siteNames,
+                DistinctAttribute = distinctAttribute
             });
 
             return this;

--- a/src/Services/Implementations/DefaultAlgoliaIndexRegister.cs
+++ b/src/Services/Implementations/DefaultAlgoliaIndexRegister.cs
@@ -13,15 +13,14 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
         private readonly Stack<AlgoliaIndex> indexes = new Stack<AlgoliaIndex>();
 
 
-        public IAlgoliaIndexRegister Add<TModel>(string indexName, IEnumerable<string> siteNames = null, string distinctAttribute = null, int distinctLevel = 0) where TModel : AlgoliaSearchModel
+        public IAlgoliaIndexRegister Add<TModel>(string indexName, IEnumerable<string> siteNames = null, DistinctOptions distinctOptions = null) where TModel : AlgoliaSearchModel
         {
             indexes.Push(new AlgoliaIndex
             {
                 IndexName = indexName,
                 Type = typeof(TModel),
                 SiteNames = siteNames,
-                DistinctAttribute = distinctAttribute,
-                DistinctLevel = distinctLevel
+                DistinctOptions = distinctOptions
             });
 
             return this;

--- a/src/Services/Implementations/DefaultAlgoliaIndexRegister.cs
+++ b/src/Services/Implementations/DefaultAlgoliaIndexRegister.cs
@@ -13,14 +13,15 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
         private readonly Stack<AlgoliaIndex> indexes = new Stack<AlgoliaIndex>();
 
 
-        public IAlgoliaIndexRegister Add<TModel>(string indexName, IEnumerable<string> siteNames = null, string distinctAttribute = null) where TModel : AlgoliaSearchModel
+        public IAlgoliaIndexRegister Add<TModel>(string indexName, IEnumerable<string> siteNames = null, string distinctAttribute = null, int distinctLevel = 0) where TModel : AlgoliaSearchModel
         {
             indexes.Push(new AlgoliaIndex
             {
                 IndexName = indexName,
                 Type = typeof(TModel),
                 SiteNames = siteNames,
-                DistinctAttribute = distinctAttribute
+                DistinctAttribute = distinctAttribute,
+                DistinctLevel = distinctLevel
             });
 
             return this;

--- a/src/Services/Implementations/DefaultAlgoliaIndexingService.cs
+++ b/src/Services/Implementations/DefaultAlgoliaIndexingService.cs
@@ -45,14 +45,14 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
 
         public void EnqueueAlgoliaItems(TreeNode node, string eventName)
         {
-            foreach (var index in algoliaRegistrationService.RegisteredIndexes)
+            foreach (var indexName in algoliaRegistrationService.RegisteredIndexes.Select(index => index.IndexName))
             {
-                if (!algoliaRegistrationService.IsNodeIndexedByIndex(node, index.IndexName))
+                if (!algoliaRegistrationService.IsNodeIndexedByIndex(node, indexName))
                 {
                     continue;
                 }
 
-                var indexedColumns = algoliaRegistrationService.GetIndexedColumnNames(index.IndexName);
+                var indexedColumns = algoliaRegistrationService.GetIndexedColumnNames(indexName);
                 if (indexedColumns.Length == 0)
                 {
                     eventLogService.LogError(nameof(DefaultAlgoliaIndexingService), nameof(EnqueueAlgoliaItems), $"Unable to enqueue node change: Error loading indexed columns.");
@@ -71,7 +71,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
                 {
                     Node = node,
                     Delete = shouldDelete,
-                    IndexName = index.IndexName
+                    IndexName = indexName
                 });
             }
         }
@@ -108,7 +108,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
             var successfulOperations = 0;
 
             // Group queue items based on index name
-            var groups = items.ToList().GroupBy(item => item.IndexName);
+            var groups = items.GroupBy(item => item.IndexName);
             foreach (var group in groups)
             {
                 try

--- a/src/Services/Implementations/DefaultAlgoliaIndexingService.cs
+++ b/src/Services/Implementations/DefaultAlgoliaIndexingService.cs
@@ -90,7 +90,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
             MapTreeNodeProperties(node, data, algoliaIndex.Type);
             MapCommonProperties(node, data);
 
-            if (!String.IsNullOrEmpty(algoliaIndex.DistinctAttribute) && algoliaIndex.DistinctLevel > 0)
+            if (algoliaIndex.DistinctOptions != null)
             {
                 var searchModel = Activator.CreateInstance(algoliaIndex.Type) as AlgoliaSearchModel;
                 return searchModel.SplitData(data);
@@ -123,7 +123,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
                     var updateTasks = group.Where(queueItem => !queueItem.Deleted);
 
                     var deleteIds = new List<string>();
-                    if (!String.IsNullOrEmpty(algoliaIndex.DistinctAttribute) && algoliaIndex.DistinctLevel > 0)
+                    if (algoliaIndex.DistinctOptions != null)
                     {
                         // Data has been split, call GetTreeNodeData to obtain IDs of the smaller records
                         foreach (var queueItem in deleteTasks)

--- a/src/Services/Implementations/DefaultAlgoliaRegistrationService.cs
+++ b/src/Services/Implementations/DefaultAlgoliaRegistrationService.cs
@@ -79,15 +79,15 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
             var facetableProperties = algoliaIndex.Type.GetProperties().Where(prop => Attribute.IsDefined(prop, typeof(FacetableAttribute)));
             var settings = new IndexSettings()
             {
-                Distinct = algoliaIndex.DistinctLevel,
                 SearchableAttributes = algoliaSearchService.OrderSearchableProperties(searchableProperties),
                 AttributesToRetrieve = retrievablProperties.Select(p => p.Name).ToList(),
                 AttributesForFaceting = facetableProperties.Select(algoliaSearchService.GetFilterablePropertyName).ToList()
             };
 
-            if (!String.IsNullOrEmpty(algoliaIndex.DistinctAttribute))
+            if (algoliaIndex.DistinctOptions != null)
             {
-                settings.AttributeForDistinct = algoliaIndex.DistinctAttribute;
+                settings.Distinct = algoliaIndex.DistinctOptions.DistinctLevel;
+                settings.AttributeForDistinct = algoliaIndex.DistinctOptions.DistinctAttribute;
             }
 
             return settings;

--- a/src/Services/Implementations/DefaultAlgoliaRegistrationService.cs
+++ b/src/Services/Implementations/DefaultAlgoliaRegistrationService.cs
@@ -24,7 +24,6 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
     {
         private readonly IAlgoliaSearchService algoliaSearchService;
         private readonly IEventLogService eventLogService;
-        private readonly ISearchClient searchClient;
         private readonly IAlgoliaIndexService algoliaIndexService;
         private readonly IAlgoliaIndexRegister algoliaIndexRegister;
         private readonly List<AlgoliaIndex> mRegisteredIndexes = new List<AlgoliaIndex>();
@@ -49,13 +48,11 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
         /// </summary>
         public DefaultAlgoliaRegistrationService(IAlgoliaSearchService algoliaSearchService,
             IEventLogService eventLogService,
-            ISearchClient searchClient,
             IAlgoliaIndexService algoliaIndexService,
             IAlgoliaIndexRegister algoliaIndexRegister)
         {
             this.algoliaSearchService = algoliaSearchService;
             this.eventLogService = eventLogService;
-            this.searchClient = searchClient;
             this.algoliaIndexService = algoliaIndexService;
             this.algoliaIndexRegister = algoliaIndexRegister;
         }
@@ -132,15 +129,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
                 throw new ArgumentNullException(nameof(node));
             }
 
-            foreach (var index in mRegisteredIndexes)
-            {
-                if (IsNodeIndexedByIndex(node, index.IndexName))
-                {
-                    return true;
-                }
-            }
-
-            return false;
+            return mRegisteredIndexes.Any(index => IsNodeIndexedByIndex(node, index.IndexName));
         }
 
 
@@ -168,8 +157,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
             }
             
             var includedPathAttributes = alogliaIndex.Type.GetCustomAttributes<IncludedPathAttribute>(false);
-            foreach (var includedPathAttribute in includedPathAttributes)
-            {
+            return includedPathAttributes.Any(includedPathAttribute => {
                 var path = includedPathAttribute.AliasPath;
                 var matchesPageType = (includedPathAttribute.PageTypes.Length == 0 || includedPathAttribute.PageTypes.Contains(node.ClassName));
                 var matchesCulture = (includedPathAttribute.Cultures.Length == 0 || includedPathAttribute.Cultures.Contains(node.DocumentCulture));
@@ -177,21 +165,13 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
                 if (path.EndsWith("/%"))
                 {
                     path = path.TrimEnd('%', '/');
-                    if (node.NodeAliasPath.StartsWith(path) && matchesPageType && matchesCulture)
-                    {
-                        return true;
-                    }
+                    return node.NodeAliasPath.StartsWith(path) && matchesPageType && matchesCulture;
                 }
                 else
                 {
-                    if (node.NodeAliasPath == path && matchesPageType && matchesCulture)
-                    {
-                        return true;
-                    }
+                    return node.NodeAliasPath == path && matchesPageType && matchesCulture;
                 }
-            }
-
-            return false;
+            });
         }
 
 

--- a/src/Services/Implementations/DefaultAlgoliaRegistrationService.cs
+++ b/src/Services/Implementations/DefaultAlgoliaRegistrationService.cs
@@ -68,22 +68,28 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
                 throw new ArgumentNullException(nameof(indexName));
             }
 
-            var alogliaIndex = mRegisteredIndexes.FirstOrDefault(i => i.IndexName == indexName);
-            if (alogliaIndex == null)
+            var algoliaIndex = mRegisteredIndexes.FirstOrDefault(i => i.IndexName == indexName);
+            if (algoliaIndex == null)
             {
                 return null;
             }
 
-            var searchableProperties = alogliaIndex.Type.GetProperties().Where(prop => Attribute.IsDefined(prop, typeof(SearchableAttribute)));
-            var retrievablProperties = alogliaIndex.Type.GetProperties().Where(prop => Attribute.IsDefined(prop, typeof(RetrievableAttribute)));
-            var facetableProperties = alogliaIndex.Type.GetProperties().Where(prop => Attribute.IsDefined(prop, typeof(FacetableAttribute)));
-            
-            return new IndexSettings()
+            var searchableProperties = algoliaIndex.Type.GetProperties().Where(prop => Attribute.IsDefined(prop, typeof(SearchableAttribute)));
+            var retrievablProperties = algoliaIndex.Type.GetProperties().Where(prop => Attribute.IsDefined(prop, typeof(RetrievableAttribute)));
+            var facetableProperties = algoliaIndex.Type.GetProperties().Where(prop => Attribute.IsDefined(prop, typeof(FacetableAttribute)));
+            var settings = new IndexSettings()
             {
                 SearchableAttributes = algoliaSearchService.OrderSearchableProperties(searchableProperties),
                 AttributesToRetrieve = retrievablProperties.Select(p => p.Name).ToList(),
                 AttributesForFaceting = facetableProperties.Select(algoliaSearchService.GetFilterablePropertyName).ToList()
             };
+
+            if (!String.IsNullOrEmpty(algoliaIndex.DistinctAttribute))
+            {
+                settings.AttributeForDistinct = algoliaIndex.DistinctAttribute;
+            }
+
+            return settings;
         }
 
 

--- a/src/Services/Implementations/DefaultAlgoliaSearchService.cs
+++ b/src/Services/Implementations/DefaultAlgoliaSearchService.cs
@@ -81,7 +81,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
                 }
             ).ToList();
 
-            if (!displayEmptyFacets)
+            if (!displayEmptyFacets || filter == null)
             {
                 return facets.ToArray();
             }
@@ -89,7 +89,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Services
             // Loop through all facets present in previous filter
             foreach (var previousFacetedAttribute in filter.FacetedAttributes)
             {
-                var matchingFacetFromResponse = facets.Where(facet => facet.Attribute == previousFacetedAttribute.Attribute).FirstOrDefault();
+                var matchingFacetFromResponse = facets.FirstOrDefault(facet => facet.Attribute == previousFacetedAttribute.Attribute);
                 if (matchingFacetFromResponse == null)
                 {
                     // Previous attribute was not returned by Algolia, add to new facet list

--- a/tests/Fakes/FakeNodes.cs
+++ b/tests/Fakes/FakeNodes.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 
 namespace Kentico.Xperience.AlgoliaSearch.Test
 {
-    internal class FakeNodes
+    internal static class FakeNodes
     {
         private static readonly Dictionary<string, TreeNode> nodes = new Dictionary<string, TreeNode>();
 

--- a/tests/Tests/IAlgoliaIndexRegisterTests.cs
+++ b/tests/Tests/IAlgoliaIndexRegisterTests.cs
@@ -61,7 +61,6 @@ namespace Kentico.Xperience.AlgoliaSearch.Test
                 return new DefaultAlgoliaRegistrationService(
                     Substitute.For<IAlgoliaSearchService>(),
                     new MockEventLogService(),
-                    Substitute.For<ISearchClient>(),
                     Substitute.For<IAlgoliaIndexService>(),
                     indexRegister);
             }

--- a/tests/Tests/IAlgoliaIndexingServiceTests.cs
+++ b/tests/Tests/IAlgoliaIndexingServiceTests.cs
@@ -43,8 +43,8 @@ namespace Kentico.Xperience.AlgoliaSearch.Test
                 });
 
                 Assert.Multiple(() => {
-                    Assert.AreEqual(nodeData.FirstOrDefault().Value<int>(nameof(AlgoliaSearchModel.DocumentPublishFrom)), 0);
-                    Assert.AreEqual(nodeData.FirstOrDefault().Value<int>(nameof(AlgoliaSearchModel.DocumentPublishTo)), Int32.MaxValue);
+                    Assert.AreEqual(0, nodeData.FirstOrDefault().Value<int>(nameof(AlgoliaSearchModel.DocumentPublishFrom)));
+                    Assert.AreEqual(Int32.MaxValue, nodeData.FirstOrDefault().Value<int>(nameof(AlgoliaSearchModel.DocumentPublishTo)));
                 });
             }
 
@@ -235,7 +235,7 @@ namespace Kentico.Xperience.AlgoliaSearch.Test
 
                 var successfulOperations = algoliaIndexingService.ProcessAlgoliaTasks(testQueueItems);
 
-                Assert.AreEqual(successfulOperations, 1);
+                Assert.AreEqual(1, successfulOperations);
             }
         }
     }

--- a/tests/Tests/IAlgoliaIndexingServiceTests.cs
+++ b/tests/Tests/IAlgoliaIndexingServiceTests.cs
@@ -184,25 +184,25 @@ namespace Kentico.Xperience.AlgoliaSearch.Test
                     new AlgoliaQueueItem
                     {
                         IndexName = Model1.IndexName,
-                        Deleted = true,
+                        Delete = true,
                         Node = node1
                     },
                     new AlgoliaQueueItem
                     {
                         IndexName = Model2.IndexName,
-                        Deleted = false,
+                        Delete = false,
                         Node = node2
                     },
                     new AlgoliaQueueItem
                     {
                         IndexName = Model3.IndexName,
-                        Deleted = true,
+                        Delete = true,
                         Node = node1
                     },
                     new AlgoliaQueueItem
                     {
                         IndexName = Model4.IndexName,
-                        Deleted = false,
+                        Delete = false,
                         Node = node2
                     }
                 };
@@ -222,13 +222,13 @@ namespace Kentico.Xperience.AlgoliaSearch.Test
                     new AlgoliaQueueItem
                     {
                         IndexName = Model1.IndexName,
-                        Deleted = true,
+                        Delete = true,
                         Node = node1
                     },
                     new AlgoliaQueueItem
                     {
                         IndexName = "FAKE_NAME",
-                        Deleted = false,
+                        Delete = false,
                         Node = node2
                     }
                 };

--- a/tests/Tests/IAlgoliaIndexingServiceTests.cs
+++ b/tests/Tests/IAlgoliaIndexingServiceTests.cs
@@ -37,11 +37,14 @@ namespace Kentico.Xperience.AlgoliaSearch.Test
             public void GetTreeNodeData_UnscheduledNode_ContainsMinMaxPublishingDates()
             {
                 var unscheduledNode = FakeNodes.GetNode("/Articles/1");
-                var nodeData = algoliaIndexingService.GetTreeNodeData(unscheduledNode, typeof(Model1));
+                var nodeData = algoliaIndexingService.GetTreeNodeData(unscheduledNode, new AlgoliaIndex {
+                    IndexName = Model1.IndexName,
+                    Type = typeof(Model1)
+                });
 
                 Assert.Multiple(() => {
-                    Assert.AreEqual(nodeData.Value<int>(nameof(AlgoliaSearchModel.DocumentPublishFrom)), 0);
-                    Assert.AreEqual(nodeData.Value<int>(nameof(AlgoliaSearchModel.DocumentPublishTo)), Int32.MaxValue);
+                    Assert.AreEqual(nodeData.FirstOrDefault().Value<int>(nameof(AlgoliaSearchModel.DocumentPublishFrom)), 0);
+                    Assert.AreEqual(nodeData.FirstOrDefault().Value<int>(nameof(AlgoliaSearchModel.DocumentPublishTo)), Int32.MaxValue);
                 });
             }
 
@@ -55,11 +58,17 @@ namespace Kentico.Xperience.AlgoliaSearch.Test
                     p.SetValue(nameof(AlgoliaSearchModel.DocumentPublishTo), new DateTime(2023, 1, 1));
                 });
 
-                var nodeData = algoliaIndexingService.GetTreeNodeData(scheduledNode, typeof(Model1));
+                var nodeData = algoliaIndexingService.GetTreeNodeData(scheduledNode, new AlgoliaIndex
+                {
+                    IndexName = Model1.IndexName,
+                    Type = typeof(Model1)
+                });
 
                 Assert.Multiple(() => {
-                    Assert.AreEqual(nodeData.Value<int>(nameof(AlgoliaSearchModel.DocumentPublishFrom)), scheduledNode.DocumentPublishFrom.ToUniversalTime().Subtract(new DateTime(1970, 1, 1)).TotalSeconds);
-                    Assert.AreEqual(nodeData.Value<int>(nameof(AlgoliaSearchModel.DocumentPublishTo)), scheduledNode.DocumentPublishTo.ToUniversalTime().Subtract(new DateTime(1970, 1, 1)).TotalSeconds);
+                    Assert.AreEqual(nodeData.FirstOrDefault().Value<int>(nameof(AlgoliaSearchModel.DocumentPublishFrom)),
+                        scheduledNode.DocumentPublishFrom.ToUniversalTime().Subtract(new DateTime(1970, 1, 1)).TotalSeconds);
+                    Assert.AreEqual(nodeData.FirstOrDefault().Value<int>(nameof(AlgoliaSearchModel.DocumentPublishTo)),
+                        scheduledNode.DocumentPublishTo.ToUniversalTime().Subtract(new DateTime(1970, 1, 1)).TotalSeconds);
                 });
             }
 
@@ -68,9 +77,13 @@ namespace Kentico.Xperience.AlgoliaSearch.Test
             public void GetTreeNodeData_PropertiesFromModel_MatchNodeValue()
             {
                 var node = FakeNodes.GetNode("/Articles/1");
-                var nodeData = algoliaIndexingService.GetTreeNodeData(node, typeof(Model1));
+                var nodeData = algoliaIndexingService.GetTreeNodeData(node, new AlgoliaIndex
+                {
+                    IndexName = Model1.IndexName,
+                    Type = typeof(Model1)
+                });
 
-                Assert.AreEqual(nodeData.Value<DateTime>(nameof(Model1.DocumentCreatedWhen)), new DateTime(2022, 1, 1));
+                Assert.AreEqual(nodeData.FirstOrDefault().Value<DateTime>(nameof(Model1.DocumentCreatedWhen)), new DateTime(2022, 1, 1));
             }
 
 
@@ -79,9 +92,13 @@ namespace Kentico.Xperience.AlgoliaSearch.Test
             {
                 var nodeAliasPath = "/Articles/1";
                 var node = FakeNodes.GetNode(nodeAliasPath);
-                var nodeData = algoliaIndexingService.GetTreeNodeData(node, typeof(Model4));
+                var nodeData = algoliaIndexingService.GetTreeNodeData(node, new AlgoliaIndex
+                {
+                    IndexName = Model4.IndexName,
+                    Type = typeof(Model4)
+                });
 
-                Assert.AreEqual(nodeData.Value<string>(nameof(Model4.Prop1)), nodeAliasPath);
+                Assert.AreEqual(nodeData.FirstOrDefault().Value<string>(nameof(Model4.Prop1)), nodeAliasPath);
             }
 
 
@@ -89,11 +106,15 @@ namespace Kentico.Xperience.AlgoliaSearch.Test
             public void GetTreeNodeData_InheritsBaseClass_ContainsNodeValuesFromAllClasses()
             {
                 var node = FakeNodes.GetNode("/Articles/1");
-                var data = algoliaIndexingService.GetTreeNodeData(node, typeof(Model7));
+                var data = algoliaIndexingService.GetTreeNodeData(node, new AlgoliaIndex
+                {
+                    IndexName = Model7.IndexName,
+                    Type = typeof(Model7)
+                });
 
                 Assert.Multiple(() => {
-                    Assert.IsNotNull(data.Value<string>(nameof(Model7.NodeAliasPath)));
-                    Assert.IsNotNull(data.Value<string>(nameof(ModelBaseClass.DocumentName)));
+                    Assert.IsNotNull(data.FirstOrDefault().Value<string>(nameof(Model7.NodeAliasPath)));
+                    Assert.IsNotNull(data.FirstOrDefault().Value<string>(nameof(ModelBaseClass.DocumentName)));
                 });
             }
 
@@ -103,11 +124,15 @@ namespace Kentico.Xperience.AlgoliaSearch.Test
             {
                 var nodeAliasPath = "/Articles/1";
                 var node = FakeNodes.GetNode(nodeAliasPath);
-                var data = algoliaIndexingService.GetTreeNodeData(node, typeof(Model7));
+                var data = algoliaIndexingService.GetTreeNodeData(node, new AlgoliaIndex
+                {
+                    IndexName = Model7.IndexName,
+                    Type = typeof(Model7)
+                });
 
                 Assert.Multiple(() => {
-                    Assert.AreEqual(nodeAliasPath.ToUpper(), data.Value<string>(nameof(Model7.NodeAliasPath)));
-                    Assert.AreEqual("NAME", data.Value<string>(nameof(ModelBaseClass.DocumentName)));
+                    Assert.AreEqual(nodeAliasPath.ToUpper(), data.FirstOrDefault().Value<string>(nameof(Model7.NodeAliasPath)));
+                    Assert.AreEqual("NAME", data.FirstOrDefault().Value<string>(nameof(ModelBaseClass.DocumentName)));
                 });
             }
         }

--- a/tests/Tests/IAlgoliaRegistrationServiceTests.cs
+++ b/tests/Tests/IAlgoliaRegistrationServiceTests.cs
@@ -5,6 +5,7 @@ using CMS.DataEngine;
 using CMS.DocumentEngine;
 using CMS.SiteProvider;
 
+using Kentico.Xperience.AlgoliaSearch.Models;
 using Kentico.Xperience.AlgoliaSearch.Services;
 
 using NSubstitute;
@@ -266,9 +267,20 @@ namespace Kentico.Xperience.AlgoliaSearch.Test
             [Test]
             public void RegisterIndex_ValidIndexes_AreRegistered()
             {
-                algoliaRegistrationService.RegisterIndex(typeof(Model1), Model1.IndexName);
-                algoliaRegistrationService.RegisterIndex(typeof(Model2), Model2.IndexName);
-                algoliaRegistrationService.RegisterIndex(typeof(Model3), Model3.IndexName);
+                algoliaRegistrationService.RegisterIndex(new AlgoliaIndex {
+                    IndexName = Model1.IndexName,
+                    Type = typeof(Model1)
+                });
+                algoliaRegistrationService.RegisterIndex(new AlgoliaIndex
+                {
+                    IndexName = Model2.IndexName,
+                    Type = typeof(Model2)
+                });
+                algoliaRegistrationService.RegisterIndex(new AlgoliaIndex
+                {
+                    IndexName = Model3.IndexName,
+                    Type = typeof(Model3)
+                });
 
                 Assert.AreEqual(3, algoliaRegistrationService.RegisteredIndexes.Count);
             }
@@ -277,7 +289,11 @@ namespace Kentico.Xperience.AlgoliaSearch.Test
             [Test]
             public void RegisterIndex_EmptyIndexName_DoesntRegisterIndex()
             {
-                algoliaRegistrationService.RegisterIndex(typeof(Model1), String.Empty);
+                algoliaRegistrationService.RegisterIndex(new AlgoliaIndex
+                {
+                    IndexName = String.Empty,
+                    Type = typeof(Model1)
+                });
 
                 Assert.AreEqual(0, algoliaRegistrationService.RegisteredIndexes.Count);
             }
@@ -286,7 +302,11 @@ namespace Kentico.Xperience.AlgoliaSearch.Test
             [Test]
             public void RegisterIndex_NullSearchModel_DoesntRegisterIndex()
             {
-                algoliaRegistrationService.RegisterIndex(null, "FAKE_NAME");
+                algoliaRegistrationService.RegisterIndex(new AlgoliaIndex
+                {
+                    IndexName = "FAKE_NAME",
+                    Type = null
+                });
 
                 Assert.AreEqual(0, algoliaRegistrationService.RegisteredIndexes.Count);
             }
@@ -295,8 +315,16 @@ namespace Kentico.Xperience.AlgoliaSearch.Test
             [Test]
             public void RegisterIndex_DuplicateIndexName_DoesntRegisterIndex()
             {
-                algoliaRegistrationService.RegisterIndex(typeof(Model1), Model1.IndexName);
-                algoliaRegistrationService.RegisterIndex(typeof(Model1), Model1.IndexName);
+                algoliaRegistrationService.RegisterIndex(new AlgoliaIndex
+                {
+                    IndexName = Model1.IndexName,
+                    Type = typeof(Model1)
+                });
+                algoliaRegistrationService.RegisterIndex(new AlgoliaIndex
+                {
+                    IndexName = Model1.IndexName,
+                    Type = typeof(Model1)
+                });
 
                 Assert.AreEqual(1, algoliaRegistrationService.RegisteredIndexes.Count);
             }

--- a/tests/Tests/IAlgoliaRegistrationServiceTests.cs
+++ b/tests/Tests/IAlgoliaRegistrationServiceTests.cs
@@ -29,12 +29,10 @@ namespace Kentico.Xperience.AlgoliaSearch.Test
             [SetUp]
             public void GetIndexSettingsTests_SetUp()
             {
-                var mockSearchClient = Substitute.For<ISearchClient>();
-                var algoliaSearchService = new DefaultAlgoliaSearchService(mockSearchClient, Substitute.For<IAppSettingsService>());
+                var algoliaSearchService = new DefaultAlgoliaSearchService(Substitute.For<ISearchClient>(), Substitute.For<IAppSettingsService>());
                 algoliaRegistrationService = new DefaultAlgoliaRegistrationService(
                     algoliaSearchService,
                     new MockEventLogService(),
-                    mockSearchClient,
                     Substitute.For<IAlgoliaIndexService>(),
                     Substitute.For<IAlgoliaIndexRegister>());
                 algoliaRegistrationService.RegisterAlgoliaIndexes();
@@ -110,7 +108,6 @@ namespace Kentico.Xperience.AlgoliaSearch.Test
                 algoliaRegistrationService = new DefaultAlgoliaRegistrationService(
                     Substitute.For<IAlgoliaSearchService>(),
                     new MockEventLogService(),
-                    Substitute.For<ISearchClient>(),
                     Substitute.For<IAlgoliaIndexService>(),
                     Substitute.For<IAlgoliaIndexRegister>());
                 algoliaRegistrationService.RegisterAlgoliaIndexes();
@@ -149,33 +146,32 @@ namespace Kentico.Xperience.AlgoliaSearch.Test
                 algoliaRegistrationService = new DefaultAlgoliaRegistrationService(
                     Substitute.For<IAlgoliaSearchService>(),
                     new MockEventLogService(),
-                    Substitute.For<ISearchClient>(),
                     Substitute.For<IAlgoliaIndexService>(),
                     Substitute.For<IAlgoliaIndexRegister>());
                 algoliaRegistrationService.RegisterAlgoliaIndexes();
             }
 
 
-            [TestCase(Model1.IndexName, "/Articles/1", ExpectedResult = true)]
-            [TestCase(Model2.IndexName, "/Articles/1", ExpectedResult = true)]
-            [TestCase(Model2.IndexName, "/CZ/Articles/1", ExpectedResult = true)]
-            [TestCase(Model3.IndexName, "/Articles/1", ExpectedResult = true)]
-            [TestCase(Model4.IndexName, "/Store/Products/1", ExpectedResult = true)]
-            public bool IsNodeIndexedByIndex_NodesWithCorrectPath_ReturnsTrue(string indexName, string nodeAliasPath)
+            [TestCase(Model1.IndexName, "/Articles/1")]
+            [TestCase(Model2.IndexName, "/Articles/1")]
+            [TestCase(Model2.IndexName, "/CZ/Articles/1")]
+            [TestCase(Model3.IndexName, "/Articles/1")]
+            [TestCase(Model4.IndexName, "/Store/Products/1")]
+            public void IsNodeIndexedByIndex_NodesWithCorrectPath_ReturnsTrue(string indexName, string nodeAliasPath)
             {
                 var node = FakeNodes.GetNode(nodeAliasPath);
-                return algoliaRegistrationService.IsNodeIndexedByIndex(node, indexName);
+                Assert.True(algoliaRegistrationService.IsNodeIndexedByIndex(node, indexName));
             }
 
 
-            [TestCase(Model1.IndexName, "/CZ/Articles/1", ExpectedResult = false)]
-            [TestCase(Model2.IndexName, "/Store/Products/1", ExpectedResult = false)]
-            [TestCase(Model3.IndexName, "/CZ/Articles/1", ExpectedResult = false)]
-            [TestCase(Model3.IndexName, "/Store/Products/1", ExpectedResult = false)]
-            public bool IsNodeIndexedByIndex_NodesWithIncorrectPath_ReturnsFalse(string indexName, string nodeAliasPath)
+            [TestCase(Model1.IndexName, "/CZ/Articles/1")]
+            [TestCase(Model2.IndexName, "/Store/Products/1")]
+            [TestCase(Model3.IndexName, "/CZ/Articles/1")]
+            [TestCase(Model3.IndexName, "/Store/Products/1")]
+            public void IsNodeIndexedByIndex_NodesWithIncorrectPath_ReturnsFalse(string indexName, string nodeAliasPath)
             {
                 var node = FakeNodes.GetNode(nodeAliasPath);
-                return algoliaRegistrationService.IsNodeIndexedByIndex(node, indexName);
+                Assert.False(algoliaRegistrationService.IsNodeIndexedByIndex(node, indexName));
             }
 
 
@@ -224,7 +220,6 @@ namespace Kentico.Xperience.AlgoliaSearch.Test
                 algoliaRegistrationService = new DefaultAlgoliaRegistrationService(
                     Substitute.For<IAlgoliaSearchService>(),
                     new MockEventLogService(),
-                    Substitute.For<ISearchClient>(),
                     Substitute.For<IAlgoliaIndexService>(),
                     Substitute.For<IAlgoliaIndexRegister>());
                 algoliaRegistrationService.RegisterAlgoliaIndexes();
@@ -258,7 +253,6 @@ namespace Kentico.Xperience.AlgoliaSearch.Test
                 algoliaRegistrationService = new DefaultAlgoliaRegistrationService(
                     Substitute.For<IAlgoliaSearchService>(),
                     new MockEventLogService(),
-                    Substitute.For<ISearchClient>(),
                     Substitute.For<IAlgoliaIndexService>(),
                     Substitute.For<IAlgoliaIndexRegister>());
             }

--- a/tests/Tests/IAlgoliaSearchServiceTests.cs
+++ b/tests/Tests/IAlgoliaSearchServiceTests.cs
@@ -73,12 +73,12 @@ namespace Kentico.Xperience.AlgoliaSearch.Test
                 Assert.Multiple(() => {
                     Assert.True(facets.Any(attr => attr.Attribute == "attr1"));
                     Assert.True(facets.Any(attr => attr.Attribute == "attr2"));
-                    Assert.True(facets.Where(attr => attr.Attribute == "attr1").FirstOrDefault().Facets.Any(facet => facet.Value == "facet1"));
-                    Assert.True(facets.Where(attr => attr.Attribute == "attr2").FirstOrDefault().Facets.Any(facet => facet.Value == "facet2"));
-                    Assert.True(facets.Where(attr => attr.Attribute == "attr2").FirstOrDefault().Facets.Any(facet => facet.Value == "facet3"));
-                    Assert.True(facets.Where(attr => attr.Attribute == "attr1").FirstOrDefault().Facets.Where(facet => facet.Value == "facet1").FirstOrDefault().Count == 1);
-                    Assert.True(facets.Where(attr => attr.Attribute == "attr2").FirstOrDefault().Facets.Where(facet => facet.Value == "facet2").FirstOrDefault().Count == 2);
-                    Assert.True(facets.Where(attr => attr.Attribute == "attr2").FirstOrDefault().Facets.Where(facet => facet.Value == "facet3").FirstOrDefault().Count == 3);
+                    Assert.True(facets.FirstOrDefault(attr => attr.Attribute == "attr1").Facets.Any(facet => facet.Value == "facet1"));
+                    Assert.True(facets.FirstOrDefault(attr => attr.Attribute == "attr2").Facets.Any(facet => facet.Value == "facet2"));
+                    Assert.True(facets.FirstOrDefault(attr => attr.Attribute == "attr2").Facets.Any(facet => facet.Value == "facet3"));
+                    Assert.True(facets.FirstOrDefault(attr => attr.Attribute == "attr1").Facets.FirstOrDefault(facet => facet.Value == "facet1").Count == 1);
+                    Assert.True(facets.FirstOrDefault(attr => attr.Attribute == "attr2").Facets.FirstOrDefault(facet => facet.Value == "facet2").Count == 2);
+                    Assert.True(facets.FirstOrDefault(attr => attr.Attribute == "attr2").Facets.FirstOrDefault(facet => facet.Value == "facet3").Count == 3);
                 });
             }
 
@@ -92,14 +92,14 @@ namespace Kentico.Xperience.AlgoliaSearch.Test
                 Assert.Multiple(() => {
                     Assert.True(facets.Any(attr => attr.Attribute == "attr1"));
                     Assert.True(facets.Any(attr => attr.Attribute == "attr2"));
-                    Assert.True(facets.Where(attr => attr.Attribute == "attr1").FirstOrDefault().Facets.Any(facet => facet.Value == "facet0"));
-                    Assert.True(facets.Where(attr => attr.Attribute == "attr1").FirstOrDefault().Facets.Any(facet => facet.Value == "facet1"));
-                    Assert.True(facets.Where(attr => attr.Attribute == "attr2").FirstOrDefault().Facets.Any(facet => facet.Value == "facet2"));
-                    Assert.True(facets.Where(attr => attr.Attribute == "attr2").FirstOrDefault().Facets.Any(facet => facet.Value == "facet3"));
-                    Assert.True(facets.Where(attr => attr.Attribute == "attr1").FirstOrDefault().Facets.Where(facet => facet.Value == "facet0").FirstOrDefault().Count == 0);
-                    Assert.True(facets.Where(attr => attr.Attribute == "attr1").FirstOrDefault().Facets.Where(facet => facet.Value == "facet1").FirstOrDefault().Count == 1);
-                    Assert.True(facets.Where(attr => attr.Attribute == "attr2").FirstOrDefault().Facets.Where(facet => facet.Value == "facet2").FirstOrDefault().Count == 2);
-                    Assert.True(facets.Where(attr => attr.Attribute == "attr2").FirstOrDefault().Facets.Where(facet => facet.Value == "facet3").FirstOrDefault().Count == 3);
+                    Assert.True(facets.FirstOrDefault(attr => attr.Attribute == "attr1").Facets.Any(facet => facet.Value == "facet0"));
+                    Assert.True(facets.FirstOrDefault(attr => attr.Attribute == "attr1").Facets.Any(facet => facet.Value == "facet1"));
+                    Assert.True(facets.FirstOrDefault(attr => attr.Attribute == "attr2").Facets.Any(facet => facet.Value == "facet2"));
+                    Assert.True(facets.FirstOrDefault(attr => attr.Attribute == "attr2").Facets.Any(facet => facet.Value == "facet3"));
+                    Assert.True(facets.FirstOrDefault(attr => attr.Attribute == "attr1").Facets.FirstOrDefault(facet => facet.Value == "facet0").Count == 0);
+                    Assert.True(facets.FirstOrDefault(attr => attr.Attribute == "attr1").Facets.FirstOrDefault(facet => facet.Value == "facet1").Count == 1);
+                    Assert.True(facets.FirstOrDefault(attr => attr.Attribute == "attr2").Facets.FirstOrDefault(facet => facet.Value == "facet2").Count == 2);
+                    Assert.True(facets.FirstOrDefault(attr => attr.Attribute == "attr2").Facets.FirstOrDefault(facet => facet.Value == "facet3").Count == 3);
                 });
             }
 
@@ -113,14 +113,14 @@ namespace Kentico.Xperience.AlgoliaSearch.Test
                 Assert.Multiple(() => {
                     Assert.True(facets.Any(attr => attr.Attribute == "attr1"));
                     Assert.True(facets.Any(attr => attr.Attribute == "attr2"));
-                    Assert.True(facets.Where(attr => attr.Attribute == "attr1").FirstOrDefault().Facets.Any(facet => facet.Value == "facet1"));
-                    Assert.True(facets.Where(attr => attr.Attribute == "attr2").FirstOrDefault().Facets.Any(facet => facet.Value == "facet2"));
-                    Assert.True(facets.Where(attr => attr.Attribute == "attr2").FirstOrDefault().Facets.Any(facet => facet.Value == "facet3"));
-                    Assert.True(facets.Where(attr => attr.Attribute == "attr1").FirstOrDefault().Facets.Where(facet => facet.Value == "facet1").FirstOrDefault().Count == 1);
-                    Assert.True(facets.Where(attr => attr.Attribute == "attr2").FirstOrDefault().Facets.Where(facet => facet.Value == "facet2").FirstOrDefault().Count == 2);
-                    Assert.True(facets.Where(attr => attr.Attribute == "attr2").FirstOrDefault().Facets.Where(facet => facet.Value == "facet3").FirstOrDefault().Count == 3);
+                    Assert.True(facets.FirstOrDefault(attr => attr.Attribute == "attr1").Facets.Any(facet => facet.Value == "facet1"));
+                    Assert.True(facets.FirstOrDefault(attr => attr.Attribute == "attr2").Facets.Any(facet => facet.Value == "facet2"));
+                    Assert.True(facets.FirstOrDefault(attr => attr.Attribute == "attr2").Facets.Any(facet => facet.Value == "facet3"));
+                    Assert.True(facets.FirstOrDefault(attr => attr.Attribute == "attr1").Facets.FirstOrDefault(facet => facet.Value == "facet1").Count == 1);
+                    Assert.True(facets.FirstOrDefault(attr => attr.Attribute == "attr2").Facets.FirstOrDefault(facet => facet.Value == "facet2").Count == 2);
+                    Assert.True(facets.FirstOrDefault(attr => attr.Attribute == "attr2").Facets.FirstOrDefault(facet => facet.Value == "facet3").Count == 3);
 
-                    Assert.False(facets.Where(attr => attr.Attribute == "attr1").FirstOrDefault().Facets.Any(facet => facet.Value == "facet0"));
+                    Assert.False(facets.FirstOrDefault(attr => attr.Attribute == "attr1").Facets.Any(facet => facet.Value == "facet0"));
                 });
             }
 
@@ -132,11 +132,11 @@ namespace Kentico.Xperience.AlgoliaSearch.Test
                 var facets = algoliaSearchService.GetFacetedAttributes(facetsFromResponse, filter);
 
                 Assert.Multiple(() => {
-                    Assert.True(facets.Where(attr => attr.Attribute == "attr1").FirstOrDefault().Facets.Where(facet => facet.Value == "facet1").FirstOrDefault().IsChecked);
-                    Assert.True(facets.Where(attr => attr.Attribute == "attr2").FirstOrDefault().Facets.Where(facet => facet.Value == "facet3").FirstOrDefault().IsChecked);
+                    Assert.True(facets.FirstOrDefault(attr => attr.Attribute == "attr1").Facets.FirstOrDefault(facet => facet.Value == "facet1").IsChecked);
+                    Assert.True(facets.FirstOrDefault(attr => attr.Attribute == "attr2").Facets.FirstOrDefault(facet => facet.Value == "facet3").IsChecked);
 
-                    Assert.False(facets.Where(attr => attr.Attribute == "attr1").FirstOrDefault().Facets.Where(facet => facet.Value == "facet0").FirstOrDefault().IsChecked);
-                    Assert.False(facets.Where(attr => attr.Attribute == "attr2").FirstOrDefault().Facets.Where(facet => facet.Value == "facet2").FirstOrDefault().IsChecked);
+                    Assert.False(facets.FirstOrDefault(attr => attr.Attribute == "attr1").Facets.FirstOrDefault(facet => facet.Value == "facet0").IsChecked);
+                    Assert.False(facets.FirstOrDefault(attr => attr.Attribute == "attr2").Facets.FirstOrDefault(facet => facet.Value == "facet2").IsChecked);
                 });
             }
         }


### PR DESCRIPTION
### Motivation

Implements #19 

### Checklist

- [X] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [X] Tests are passing
- [ ] Docs have been updated (if applicable)
- [X] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Register an index using the new `DistinctOptions` parameter:

```cs
Service.Use<IAlgoliaIndexRegister>(new DefaultAlgoliaIndexRegister()
                .Add<SiteSearchModel>(SiteSearchModel.IndexName, distinctOptions: new DistinctOptions(nameof(SiteSearchModel.DocumentName), 1))
```

In the search model, implement the `AlgoliaSearchModel.SplitData` method to generate multiple `JObject`s with the desired data. For example, split a large "Content" value by paragraph:

```cs
public override IEnumerable<JObject> SplitData(JObject originalData)
{
    var originalId = originalData.Value<string>("objectID");
    var content = originalData.Value<string>(nameof(Content));
    System.Text.RegularExpressions.Match m = System.Text.RegularExpressions.Regex.Match(content, @"<p>\s*(.+?)\s*</p>");
    List<string> paragraphs = new List<string>();
    while (m.Success)
    {
        paragraphs.Add(m.Value);
        m = m.NextMatch();
    }

    return paragraphs.Select((p, index) => {
        var data = (JObject)originalData.DeepClone();
        data["objectID"] = $"{originalId}-{index}";
        data[nameof(Content)] = p;
        return data;
    });
}
```

On page creation/update, multiple records should be created within Algolia containing only a single paragraph. On page deletion, all "chunks" in Algolia are deleted. While searching on the front end, only the most relevant "chunk" should be returned (when using `DistinctLevel` of 1).
